### PR TITLE
feat: localize Energy Analyzer multiblock names

### DIFF
--- a/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentDetailDialog.java
+++ b/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentDetailDialog.java
@@ -1,9 +1,9 @@
 package com.gtceuterminal.client.gui.dialog;
 
-import com.gtceuterminal.common.multiblock.ComponentType;
 import com.gtceuterminal.common.theme.ItemTheme;
 import com.gtceuterminal.common.multiblock.ComponentGroup;
 import com.gtceuterminal.common.multiblock.ComponentInfo;
+import com.gtceuterminal.common.multiblock.ComponentType;
 import com.gtceuterminal.common.multiblock.MultiblockInfo;
 
 import com.lowdragmc.lowdraglib.gui.widget.ButtonWidget;

--- a/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentDetailDialog.java
+++ b/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentDetailDialog.java
@@ -1,5 +1,6 @@
 package com.gtceuterminal.client.gui.dialog;
 
+import com.gtceuterminal.common.multiblock.ComponentType;
 import com.gtceuterminal.common.theme.ItemTheme;
 import com.gtceuterminal.common.multiblock.ComponentGroup;
 import com.gtceuterminal.common.multiblock.ComponentInfo;
@@ -328,19 +329,8 @@ public class ComponentDetailDialog extends DialogWidget {
 
     private static String tierNameForList(ComponentGroup group, ComponentInfo rep) {
         try {
-            if (group != null && group.getType() == com.gtceuterminal.common.multiblock.ComponentType.COIL) {
-                String k = "gui.gtceuterminal.coil_tier." + switch (rep.getTier()) {
-                    case 0 -> "cupronickel";
-                    case 1 -> "kanthal";
-                    case 2 -> "nichrome";
-                    case 3 -> "rtm_alloy";
-                    case 4 -> "hss_g";
-                    case 5 -> "naquadah";
-                    case 6 -> "trinium";
-                    case 7 -> "tritanium";
-                    default -> "unknown";
-                };
-                return net.minecraft.network.chat.Component.translatable(k).getString();
+            if (group != null && group.getType() == ComponentType.COIL) {
+                return ComponentType.getCoilTierName(rep.getTier());
             }
         } catch (Throwable ignored) {}
         String s = rep != null ? rep.getTierName() : "";

--- a/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentDetailDialog.java
+++ b/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentDetailDialog.java
@@ -299,7 +299,7 @@ public class ComponentDetailDialog extends DialogWidget {
 
             entry.addWidget(new ImageWidget(6, 14, 7, 7, new ColorRectTexture(COLOR_SUCCESS)));
 
-            String typeName = group.getType().name().replace("_", " ");
+            String typeName = group.getType().getDisplayNameComponent().getString();
             LabelWidget typeLabel = new LabelWidget(18, 4, "§f" + typeName);
             typeLabel.setTextColor(COLOR_TEXT_WHITE);
             entry.addWidget(typeLabel);
@@ -314,7 +314,7 @@ public class ComponentDetailDialog extends DialogWidget {
 
             String tierText = Component.translatable(
                     "gui.gtceuterminal.component_detail_dialog.entry.tier",
-                    rep.getTierName()
+                    tierNameForList(group, rep)
             ).getString();
             if (!rep.getPossibleUpgradeTiers().isEmpty()) tierText += " §a→";
 
@@ -324,6 +324,27 @@ public class ComponentDetailDialog extends DialogWidget {
         }
 
         return entry;
+    }
+
+    private static String tierNameForList(ComponentGroup group, ComponentInfo rep) {
+        try {
+            if (group != null && group.getType() == com.gtceuterminal.common.multiblock.ComponentType.COIL) {
+                String k = "gui.gtceuterminal.coil_tier." + switch (rep.getTier()) {
+                    case 0 -> "cupronickel";
+                    case 1 -> "kanthal";
+                    case 2 -> "nichrome";
+                    case 3 -> "rtm_alloy";
+                    case 4 -> "hss_g";
+                    case 5 -> "naquadah";
+                    case 6 -> "trinium";
+                    case 7 -> "tritanium";
+                    default -> "unknown";
+                };
+                return net.minecraft.network.chat.Component.translatable(k).getString();
+            }
+        } catch (Throwable ignored) {}
+        String s = rep != null ? rep.getTierName() : "";
+        return s != null ? s : "";
     }
 
     private ButtonWidget createCloseButton() {

--- a/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentUpgradeDialog.java
+++ b/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentUpgradeDialog.java
@@ -1,6 +1,5 @@
 package com.gtceuterminal.client.gui.dialog;
 
-import com.gtceuterminal.common.theme.ItemTheme;
 import com.gtceuterminal.GTCEUTerminalMod;
 import com.gtceuterminal.client.gui.multiblock.ComponentDetailUI;
 import com.gtceuterminal.client.gui.widget.LDLMaterialListWidget;
@@ -15,6 +14,7 @@ import com.gtceuterminal.common.multiblock.ComponentType;
 import com.gtceuterminal.common.multiblock.MultiblockInfo;
 import com.gtceuterminal.common.network.CPacketComponentUpgrade;
 import com.gtceuterminal.common.network.TerminalNetwork;
+import com.gtceuterminal.common.theme.ItemTheme;
 import com.gtceuterminal.common.upgrade.UniversalUpgradeCatalog;
 import com.gtceuterminal.common.upgrade.UniversalUpgradeCatalogBuilder;
 

--- a/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentUpgradeDialog.java
+++ b/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentUpgradeDialog.java
@@ -266,10 +266,14 @@ public class ComponentUpgradeDialog extends DialogWidget {
             countLabel.setTextColor(COLOR_TEXT_WHITE);
             panel.addWidget(countLabel);
 
+            String tierName = rep.getTierName();
+            if (rep.getType() == ComponentType.COIL) {
+                tierName = ComponentType.getCoilTierName(rep.getTier());
+            }
             LabelWidget currentLabel = new LabelWidget(10, 18,
                     Component.translatable(
                             "gui.gtceuterminal.component_upgrade_dialog.info.current_tier",
-                            rep.getTierName()
+                            tierName
                     ).getString());
             currentLabel.setTextColor(COLOR_TEXT_WHITE);
             panel.addWidget(currentLabel);

--- a/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentUpgradeDialog.java
+++ b/src/main/java/com/gtceuterminal/client/gui/dialog/ComponentUpgradeDialog.java
@@ -243,7 +243,7 @@ public class ComponentUpgradeDialog extends DialogWidget {
 
         String title = Component.translatable(
                 "gui.gtceuterminal.component_upgrade_dialog.title",
-                group.getType().name().replace("_", " ")
+                group.getType().getDisplayNameComponent()
         ).getString();
         LabelWidget titleLabel = new LabelWidget(10, 7, title);
         titleLabel.setTextColor(COLOR_TEXT_WHITE);
@@ -500,7 +500,17 @@ public class ComponentUpgradeDialog extends DialogWidget {
                 yPos += btnHeight + spacing;
             }
 
-            String name = (e.displayName != null && !e.displayName.isBlank()) ? e.displayName : e.blockId;
+            String name = e.blockId;
+            try {
+                Block b = BuiltInRegistries.BLOCK.get(net.minecraft.resources.ResourceLocation.tryParse(e.blockId));
+                if (b != null) {
+                    String loc = Component.translatable(b.getDescriptionId()).getString();
+                    if (loc != null && !loc.isBlank()) name = loc;
+                }
+            } catch (Exception ignored) {}
+            if (name == null || name.isBlank()) {
+                name = (e.displayName != null && !e.displayName.isBlank()) ? e.displayName : e.blockId;
+            }
             name = trimCommonSuffixes(name);
 
             String tierTag = (e.tierName != null && !e.tierName.isBlank()) ? e.tierName : safeTierName(e.tier);

--- a/src/main/java/com/gtceuterminal/client/gui/dialog/GroupUpgradeDialog.java
+++ b/src/main/java/com/gtceuterminal/client/gui/dialog/GroupUpgradeDialog.java
@@ -1,6 +1,8 @@
 package com.gtceuterminal.client.gui.dialog;
 
 import com.gregtechceu.gtceu.api.GTValues;
+import com.gregtechceu.gtceu.api.GTCEuAPI;
+import com.gregtechceu.gtceu.api.block.ICoilType;
 
 import com.gtceuterminal.common.theme.ItemTheme;
 import com.gtceuterminal.common.material.ComponentUpgradeHelper;
@@ -23,6 +25,8 @@ import com.lowdragmc.lowdraglib.utils.Size;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.Item;
 import net.minecraft.util.Mth;
@@ -184,9 +188,9 @@ public class GroupUpgradeDialog extends DialogWidget {
         int yPos = 8;
 
         // Component count and name
-        String componentName = group.getType().getDisplayName();
+        Component componentName = group.getType().getDisplayNameComponent();
         LabelWidget countLabel = new LabelWidget(10, yPos,
-                net.minecraft.network.chat.Component.translatable(
+                Component.translatable(
                         "gui.gtceuterminal.group_upgrade_dialog.upgrade_x",
                         group.getCount(),
                         componentName
@@ -197,9 +201,9 @@ public class GroupUpgradeDialog extends DialogWidget {
         yPos += 15;
 
         // From tier
-        String fromName = getDisplayName(group.getType(), group.getTier());
+        Component fromName = getTierDisplayName(group.getType(), group.getTier());
         LabelWidget fromLabel = new LabelWidget(10, yPos,
-                net.minecraft.network.chat.Component.translatable(
+                Component.translatable(
                         "gui.gtceuterminal.group_upgrade_dialog.from",
                         fromName
                 ).getString());
@@ -209,9 +213,9 @@ public class GroupUpgradeDialog extends DialogWidget {
         yPos += 12;
 
         // To tier
-        String toName = getDisplayName(group.getType(), targetTier);
+        Component toName = getTierDisplayName(group.getType(), targetTier);
         LabelWidget toLabel = new LabelWidget(10, yPos,
-                net.minecraft.network.chat.Component.translatable(
+                Component.translatable(
                         "gui.gtceuterminal.group_upgrade_dialog.to",
                         toName
                 ).getString());
@@ -362,28 +366,38 @@ public class GroupUpgradeDialog extends DialogWidget {
         }
     }
 
-    private String getDisplayName(ComponentType type, int tier) {
+    private Component getTierDisplayName(ComponentType type, int tier) {
         if (type == ComponentType.COIL) {
-            return getCoilName(tier);
+            return getCoilNameComponent(tier);
         } else if (type == ComponentType.MAINTENANCE) {
-            return type.getDisplayName();
+            return type.getDisplayNameComponent();
         } else {
             String tierName = GTValues.VN[tier].toUpperCase(Locale.ROOT);
-            return type.getDisplayName() + " (" + tierName + ")";
+            return Component.translatable(
+                    "gui.gtceuterminal.group_upgrade_dialog.type_with_tier",
+                    type.getDisplayNameComponent(),
+                    tierName
+            );
         }
     }
 
-    private String getCoilName(int tier) {
-        return switch (tier) {
-            case 0 -> "Cupronickel";
-            case 1 -> "Kanthal";
-            case 2 -> "Nichrome";
-            case 3 -> "RTM Alloy";
-            case 4 -> "HSS-G";
-            case 5 -> "Naquadah";
-            case 6 -> "Trinium";
-            case 7 -> "Tritanium";
-            default -> net.minecraft.network.chat.Component.translatable("gui.gtceuterminal.group_upgrade_dialog.unknown_coil").getString();
-        };
+    private Component getCoilNameComponent(int tier) {
+        try {
+            for (var entry : GTCEuAPI.HEATING_COILS.entrySet()) {
+                ICoilType coilType = entry.getKey();
+                if (coilType == null) continue;
+                if (coilType.getTier() != tier) continue;
+                var sup = entry.getValue();
+                var block = sup != null ? sup.get() : null;
+                if (block != null) {
+                    return Component.translatable(block.getDescriptionId());
+                }
+                String fallback = coilType.getName();
+                if (fallback != null && !fallback.isBlank()) {
+                    return Component.literal(fallback);
+                }
+            }
+        } catch (Exception ignored) {}
+        return Component.translatable("gui.gtceuterminal.group_upgrade_dialog.unknown_coil");
     }
 }

--- a/src/main/java/com/gtceuterminal/client/gui/energy/EnergyAnalyzerUI.java
+++ b/src/main/java/com/gtceuterminal/client/gui/energy/EnergyAnalyzerUI.java
@@ -170,7 +170,7 @@ public class EnergyAnalyzerUI {
             g.addWidget(dot);
 
             LabelWidget name = new LabelWidget(PAD + 12, y + 4,
-                    () -> truncate(m.getDisplayName(), 14));
+                    () -> truncate(m.getDisplayNameComponent().getString(), 14));
             name.setClientSideWidget();
             name.setTextColor(C_GRAY);
             g.addWidget(name);
@@ -208,7 +208,8 @@ public class EnergyAnalyzerUI {
 
         // Machine name
         LabelWidget title = new LabelWidget(0, y, () -> {
-            EnergySnapshot s = selSnap(); return s != null ? s.machineName : "";
+            EnergySnapshot s = selSnap();
+            return s != null ? s.getMachineTitle().getString() : "";
         });
         title.setClientSideWidget();
         title.setTextColor(C_WHITE);
@@ -395,7 +396,21 @@ public class EnergyAnalyzerUI {
                 String inOut = hatch.isInput()
                         ? Component.translatable("gui.gtceuterminal.energy_analyzer.hatch_in").getString()
                         : Component.translatable("gui.gtceuterminal.energy_analyzer.hatch_out").getString();
-                return "  " + inOut + "  " + hatch.name() + "  " + hatch.voltage() + "V";
+                String ampSuffix = hatch.amperage() > 1
+                        ? Component.translatable(
+                                "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix",
+                                hatch.amperage()
+                        ).getString()
+                        : "";
+                String blockKey = hatch.blockNameKey();
+                if (blockKey == null || blockKey.isBlank()) return "";
+                return Component.translatable(
+                        "gui.gtceuterminal.energy_analyzer.hatch_line",
+                        inOut,
+                        Component.translatable(blockKey),
+                        hatch.voltage(),
+                        ampSuffix
+                ).getString();
             });
             hatchL.setClientSideWidget();
             hatchL.setTextColor(C_GREEN);
@@ -552,7 +567,7 @@ public class EnergyAnalyzerUI {
 
         // Machine name subtitle
         LabelWidget nameLbl = new LabelWidget(8, 22,
-                "§7" + truncate(m.getDisplayName(), 28));
+                "§7" + truncate(m.getDisplayNameComponent().getString(), 28));
         nameLbl.setTextColor(C_GRAY);
         panel.addWidget(nameLbl);
 
@@ -683,7 +698,7 @@ public class EnergyAnalyzerUI {
         titleBar.addWidget(titleLbl);
 
         // Confirm message
-        String targetName = truncate(m.getDisplayName(), 22);
+        String targetName = truncate(m.getDisplayNameComponent().getString(), 22);
         LabelWidget confirmLbl = new LabelWidget(8, 22,
                 Component.translatable(
                                 "gui.gtceuterminal.energy_analyzer.unlink_dialog.remove_prompt",
@@ -749,7 +764,7 @@ public class EnergyAnalyzerUI {
         titleBar.setBackground(new ColorRectTexture(0xFF2D2D2D));
         panel.addWidget(titleBar);
         LabelWidget titleLbl = new LabelWidget(8, 4,
-                Component.translatable("gui.gtceuterminal.energy_analyzer.recipe_log.title", snap.machineName).getString());
+                Component.translatable("gui.gtceuterminal.energy_analyzer.recipe_log.title", snap.getMachineTitle()).getString());
         titleLbl.setTextColor(C_GOLD);
         titleBar.addWidget(titleLbl);
 

--- a/src/main/java/com/gtceuterminal/client/gui/energy/EnergyUpdateWidget.java
+++ b/src/main/java/com/gtceuterminal/client/gui/energy/EnergyUpdateWidget.java
@@ -70,11 +70,10 @@ public class EnergyUpdateWidget extends Widget {
 
             if (targetLevel != null) {
                 result.add(EnergyDataCollector.collect(
-                        targetLevel, m.getPos(), m.getCustomName(), m.getMachineType()));
+                        targetLevel, m.getPos(), m.getCustomName(), m.getControllerBlockKey()));
             } else {
                 EnergySnapshot offline = new EnergySnapshot();
-                offline.machineName = m.getDisplayName();
-                offline.machineType = m.getMachineType();
+                m.applyToSnapshotIdentity(offline);
                 offline.mode = EnergySnapshot.MachineMode.UNKNOWN;
                 offline.isFormed = false;
                 result.add(offline);

--- a/src/main/java/com/gtceuterminal/client/gui/factory/EnergyAnalyzerUIFactory.java
+++ b/src/main/java/com/gtceuterminal/client/gui/factory/EnergyAnalyzerUIFactory.java
@@ -58,11 +58,10 @@ public class EnergyAnalyzerUIFactory extends UIFactory<EnergyAnalyzerUIFactory.E
             }
             if (targetLevel != null) {
                 snapshots.add(EnergyDataCollector.collect(
-                        targetLevel, m.getPos(), m.getCustomName(), m.getMachineType()));
+                        targetLevel, m.getPos(), m.getCustomName(), m.getControllerBlockKey()));
             } else {
                 EnergySnapshot offline = new EnergySnapshot();
-                offline.machineName = m.getDisplayName();
-                offline.machineType = m.getMachineType();
+                m.applyToSnapshotIdentity(offline);
                 offline.mode = EnergySnapshot.MachineMode.UNKNOWN;
                 offline.isFormed = false;
                 snapshots.add(offline);

--- a/src/main/java/com/gtceuterminal/client/gui/multiblock/ComponentDetailUI.java
+++ b/src/main/java/com/gtceuterminal/client/gui/multiblock/ComponentDetailUI.java
@@ -1,12 +1,12 @@
 package com.gtceuterminal.client.gui.multiblock;
 
-import com.gtceuterminal.common.multiblock.ComponentType;
 import com.gtceuterminal.common.theme.ItemTheme;
 import com.gtceuterminal.GTCEUTerminalMod;
 import com.gtceuterminal.client.gui.dialog.ComponentUpgradeDialog;
 import com.gtceuterminal.client.gui.factory.MultiStructureManagerUIFactory;
 import com.gtceuterminal.common.multiblock.ComponentGroup;
 import com.gtceuterminal.common.multiblock.ComponentInfo;
+import com.gtceuterminal.common.multiblock.ComponentType;
 import com.gtceuterminal.common.multiblock.MultiblockInfo;
 
 import com.lowdragmc.lowdraglib.gui.modular.IUIHolder;

--- a/src/main/java/com/gtceuterminal/client/gui/multiblock/ComponentDetailUI.java
+++ b/src/main/java/com/gtceuterminal/client/gui/multiblock/ComponentDetailUI.java
@@ -1,5 +1,6 @@
 package com.gtceuterminal.client.gui.multiblock;
 
+import com.gtceuterminal.common.multiblock.ComponentType;
 import com.gtceuterminal.common.theme.ItemTheme;
 import com.gtceuterminal.GTCEUTerminalMod;
 import com.gtceuterminal.client.gui.dialog.ComponentUpgradeDialog;
@@ -289,19 +290,8 @@ public class ComponentDetailUI {
 
     private static String tierNameForList(ComponentGroup group, ComponentInfo rep) {
         try {
-            if (group != null && group.getType() == com.gtceuterminal.common.multiblock.ComponentType.COIL) {
-                String k = "gui.gtceuterminal.coil_tier." + switch (rep.getTier()) {
-                    case 0 -> "cupronickel";
-                    case 1 -> "kanthal";
-                    case 2 -> "nichrome";
-                    case 3 -> "rtm_alloy";
-                    case 4 -> "hss_g";
-                    case 5 -> "naquadah";
-                    case 6 -> "trinium";
-                    case 7 -> "tritanium";
-                    default -> "unknown";
-                };
-                return Component.translatable(k).getString();
+            if (group != null && group.getType() == ComponentType.COIL) {
+                return ComponentType.getCoilTierName(rep.getTier());
             }
         } catch (Throwable ignored) {}
         String s = rep != null ? rep.getTierName() : "";

--- a/src/main/java/com/gtceuterminal/client/gui/multiblock/ComponentDetailUI.java
+++ b/src/main/java/com/gtceuterminal/client/gui/multiblock/ComponentDetailUI.java
@@ -239,7 +239,7 @@ public class ComponentDetailUI {
             int dotY = compact ? 12 : 15;
             entry.addWidget(new ImageWidget(8, dotY, 8, 8, new ColorRectTexture(COLOR_SUCCESS)));
 
-            String typeName = group.getType().name().replace("_", " ");
+            String typeName = group.getType().getDisplayNameComponent().getString();
             addText(entry, 22, compact ? 4 : 5, entryW - 120, "§f" + typeName, textScale);
 
             addText(entry, 22, compact ? 16 : 17, 120,
@@ -247,7 +247,7 @@ public class ComponentDetailUI {
                     textScale);
 
             addText(entry, compact ? 130 : 150, compact ? 16 : 17, entryW - 220,
-                    Component.translatable("gui.gtceuterminal.component_detail.entry.tier", rep.getTierName()).getString(),
+                    Component.translatable("gui.gtceuterminal.component_detail.entry.tier", tierNameForList(group, rep)).getString(),
                     textScale);
 
             int btnW = compact ? 64 : 80;
@@ -285,6 +285,27 @@ public class ComponentDetailUI {
         }
 
         return entry;
+    }
+
+    private static String tierNameForList(ComponentGroup group, ComponentInfo rep) {
+        try {
+            if (group != null && group.getType() == com.gtceuterminal.common.multiblock.ComponentType.COIL) {
+                String k = "gui.gtceuterminal.coil_tier." + switch (rep.getTier()) {
+                    case 0 -> "cupronickel";
+                    case 1 -> "kanthal";
+                    case 2 -> "nichrome";
+                    case 3 -> "rtm_alloy";
+                    case 4 -> "hss_g";
+                    case 5 -> "naquadah";
+                    case 6 -> "trinium";
+                    case 7 -> "tritanium";
+                    default -> "unknown";
+                };
+                return Component.translatable(k).getString();
+            }
+        } catch (Throwable ignored) {}
+        String s = rep != null ? rep.getTierName() : "";
+        return s != null ? s : "";
     }
 
     private WidgetGroup createActionButtons() {

--- a/src/main/java/com/gtceuterminal/common/energy/EnergyDataCollector.java
+++ b/src/main/java/com/gtceuterminal/common/energy/EnergyDataCollector.java
@@ -4,12 +4,10 @@ import com.gtceuterminal.GTCEUTerminalMod;
 import com.gtceuterminal.common.config.ItemsConfig;
 import com.gtceuterminal.common.multiblock.MachineInferencer;
 
-import com.gregtechceu.gtceu.api.GTValues;
 import com.gregtechceu.gtceu.api.capability.GTCapabilityHelper;
 import com.gregtechceu.gtceu.api.capability.IEnergyContainer;
 import com.gregtechceu.gtceu.api.capability.IEnergyInfoProvider;
 import com.gregtechceu.gtceu.api.machine.MetaMachine;
-import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiController;
 import com.gregtechceu.gtceu.api.machine.feature.multiblock.IMultiPart;
 import com.gregtechceu.gtceu.api.machine.multiblock.PartAbility;
 import com.gregtechceu.gtceu.api.machine.multiblock.WorkableElectricMultiblockMachine;
@@ -19,8 +17,10 @@ import com.gregtechceu.gtceu.api.machine.feature.IRecipeLogicMachine;
 import com.gregtechceu.gtceu.api.machine.trait.RecipeLogic;
 
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 
 import net.minecraftforge.event.level.LevelEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -75,10 +75,10 @@ public class EnergyDataCollector {
 
     // ─── Main entry point ────────────────────────────────────────────────────
     public static EnergySnapshot collect(ServerLevel level, BlockPos pos,
-                                         String customName, String machineType) {
+                                         String customName, String controllerBlockKey) {
         EnergySnapshot snap = new EnergySnapshot();
-        snap.machineName = customName.isBlank() ? machineType : customName;
-        snap.machineType = machineType;
+        snap.machineCustomName = customName != null ? customName : "";
+        snap.machineTypeKey = typeKeyFromControllerBlock(level, pos, controllerBlockKey);
         snap.mode = EnergySnapshot.MachineMode.UNKNOWN;
         snap.isFormed = false;
 
@@ -143,11 +143,9 @@ public class EnergyDataCollector {
                 }
 
                 // Active recipe info + history tracking
-                if (snap.isFormed && snap.mode == EnergySnapshot.MachineMode.CONSUMER
-                        && electric instanceof IRecipeLogicMachine) {
-                    IRecipeLogicMachine rlm = (IRecipeLogicMachine) electric;
-                    collectRecipeInfo(rlm, snap);
-                    RecipeHistoryTracker.poll(pos, rlm);
+                if (snap.isFormed && snap.mode == EnergySnapshot.MachineMode.CONSUMER) {
+                    collectRecipeInfo(electric, snap);
+                    RecipeHistoryTracker.poll(pos, electric);
                     snap.recipeHistory = new java.util.ArrayList<>(RecipeHistoryTracker.getHistory(pos));
                 }
             }
@@ -183,6 +181,21 @@ public class EnergyDataCollector {
         }
 
         return snap;
+    }
+
+    /** Block description id for UI; uses world block if present else registry key from link data. */
+    private static String typeKeyFromControllerBlock(ServerLevel level, BlockPos pos, String controllerBlockKey) {
+        var state = level.getBlockState(pos);
+        if (!state.isAir()) {
+            return state.getBlock().getDescriptionId();
+        }
+        if (controllerBlockKey != null && !controllerBlockKey.isBlank()) {
+            Block b = ForgeRegistries.BLOCKS.getValue(ResourceLocation.parse(controllerBlockKey));
+            if (b != null) {
+                return b.getDescriptionId();
+            }
+        }
+        return "";
     }
 
     // ─── Active recipe info ──────────────────────────────────────────────────
@@ -264,10 +277,8 @@ public class EnergyDataCollector {
     }
 
     // ─── Hatch breakdown ─────────────────────────────────────────────────────
-    private static void collectHatchInfo(WorkableElectricMultiblockMachine machine, EnergySnapshot snap) {
+    private static void collectHatchInfo(WorkableElectricMultiblockMachine ctrl, EnergySnapshot snap) {
         try {
-            IMultiController ctrl = (IMultiController) machine;
-
             for (IMultiPart part : ctrl.getParts()) {
                 BlockPos partPos = part.self().getPos();
                 Level level = part.self().getLevel();
@@ -281,9 +292,9 @@ public class EnergyDataCollector {
                         || PartAbility.SUBSTATION_INPUT_ENERGY.isApplicable(part.self().getBlockState().getBlock());
 
                 // GTMThings wireless hatch detection via block registry name
-                var blockKey = ForgeRegistries.BLOCKS.getKey(part.self().getBlockState().getBlock());
-                if (blockKey != null) {
-                    String blockId = blockKey.toString().toLowerCase();
+                var regKey = ForgeRegistries.BLOCKS.getKey(part.self().getBlockState().getBlock());
+                if (regKey != null) {
+                    String blockId = regKey.toString().toLowerCase();
                     if (blockId.contains("wireless")) {
                         if (blockId.contains("input") || blockId.contains("target")) {
                             isInput = true;
@@ -293,10 +304,8 @@ public class EnergyDataCollector {
                         long vol = isInput ? ec.getInputVoltage() : ec.getOutputVoltage();
                         long amp = isInput ? ec.getInputAmperage() : ec.getOutputAmperage();
                         if (vol > 0) {
-                            String tier = GTValues.VN[com.gregtechceu.gtceu.utils.GTUtil.getTierByVoltage(vol)];
-                            String name = tier + " Wireless " + (isInput ? "Energy Input" : "Energy Output") + " Hatch";
-                            if (amp > 1) name += " " + amp + "A";
-                            snap.hatches.add(new EnergySnapshot.HatchInfo(name, vol, amp, isInput));
+                            Block hb = part.self().getBlockState().getBlock();
+                            snap.hatches.add(new EnergySnapshot.HatchInfo(hb.getDescriptionId(), vol, amp, isInput));
                             continue;
                         }
                     }
@@ -306,10 +315,8 @@ public class EnergyDataCollector {
                 long amperage = isInput ? ec.getInputAmperage() : ec.getOutputAmperage();
                 if (voltage <= 0) continue;
 
-                String tier = GTValues.VN[com.gregtechceu.gtceu.utils.GTUtil.getTierByVoltage(voltage)];
-                String name = tier + " " + (isInput ? "Energy Hatch" : "Dynamo Hatch");
-                if (amperage > 1) name += " " + amperage + "A";
-                snap.hatches.add(new EnergySnapshot.HatchInfo(name, voltage, amperage, isInput));
+                Block hatchBlock = part.self().getBlockState().getBlock();
+                snap.hatches.add(new EnergySnapshot.HatchInfo(hatchBlock.getDescriptionId(), voltage, amperage, isInput));
             }
         } catch (Exception e) {
             GTCEUTerminalMod.LOGGER.debug("Error collecting hatch info", e);

--- a/src/main/java/com/gtceuterminal/common/energy/EnergySnapshot.java
+++ b/src/main/java/com/gtceuterminal/common/energy/EnergySnapshot.java
@@ -1,6 +1,7 @@
 package com.gtceuterminal.common.energy;
 
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -12,8 +13,10 @@ public class EnergySnapshot {
     public enum MachineMode { CONSUMER, GENERATOR, STORAGE, UNKNOWN }
 
     // ─── Identity ─────────────────────────────────────────────────────────────
-    public String machineName;
-    public String machineType;
+    /** User-defined label from analyzer rename; empty for default controller block name. */
+    public String machineCustomName = "";
+    /** Block description id for the controller block (e.g. block.gtceu.ebf). */
+    public String machineTypeKey = "";
     public MachineMode mode;
     public boolean isFormed;
 
@@ -79,10 +82,11 @@ public class EnergySnapshot {
     }
 
     // ─── Hatch info ───────────────────────────────────────────────────────────
-    public record HatchInfo(String name, long voltage, long amperage, boolean isInput) {
+    /** blockNameKey = block.getDescriptionId() for the hatch block at that position. */
+    public record HatchInfo(String blockNameKey, long voltage, long amperage, boolean isInput) {
 
         public void encode(FriendlyByteBuf buf) {
-            buf.writeUtf(name);
+            buf.writeUtf(blockNameKey);
             buf.writeLong(voltage);
             buf.writeLong(amperage);
             buf.writeBoolean(isInput);
@@ -93,10 +97,21 @@ public class EnergySnapshot {
         }
     }
 
+    /** Title shown in UI: custom name or localized controller block name. */
+    public Component getMachineTitle() {
+        if (machineCustomName != null && !machineCustomName.isBlank()) {
+            return Component.literal(machineCustomName);
+        }
+        if (machineTypeKey != null && !machineTypeKey.isBlank()) {
+            return Component.translatable(machineTypeKey);
+        }
+        return Component.literal("");
+    }
+
     // ─── Network serialization ────────────────────────────────────────────────
     public void encode(FriendlyByteBuf buf) {
-        buf.writeUtf(machineName);
-        buf.writeUtf(machineType);
+        buf.writeUtf(machineCustomName);
+        buf.writeUtf(machineTypeKey);
         buf.writeEnum(mode);
         buf.writeBoolean(isFormed);
         buf.writeLong(energyStored);
@@ -138,8 +153,8 @@ public class EnergySnapshot {
     // Must be in same order as encode()
     public static EnergySnapshot decode(FriendlyByteBuf buf) {
         EnergySnapshot s = new EnergySnapshot();
-        s.machineName    = buf.readUtf();
-        s.machineType    = buf.readUtf();
+        s.machineCustomName = buf.readUtf();
+        s.machineTypeKey    = buf.readUtf();
         s.mode           = buf.readEnum(MachineMode.class);
         s.isFormed       = buf.readBoolean();
         s.energyStored   = buf.readLong();

--- a/src/main/java/com/gtceuterminal/common/energy/LinkedMachineData.java
+++ b/src/main/java/com/gtceuterminal/common/energy/LinkedMachineData.java
@@ -2,9 +2,12 @@ package com.gtceuterminal.common.energy;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.resources.ResourceKey;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+
+import net.minecraftforge.registries.ForgeRegistries;
 
 // Data class representing a linked machine for energy monitoring.
 public class LinkedMachineData {
@@ -12,13 +15,22 @@ public class LinkedMachineData {
     private BlockPos pos;
     private String dimensionId;
     private String customName;
-    private String machineType; // auto-detected display name
+    /** Registry key of the controller block, e.g. {@code gtceu:electric_blast_furnace}. */
+    private String controllerBlockKey;
+    /** Legacy English display from old saves when only {@code Type} was stored. */
+    private String legacyTypeDisplay;
 
-    public LinkedMachineData(BlockPos pos, String dimensionId, String customName, String machineType) {
+    public LinkedMachineData(BlockPos pos, String dimensionId, String customName, String controllerBlockKey) {
+        this(pos, dimensionId, customName, controllerBlockKey, "");
+    }
+
+    public LinkedMachineData(BlockPos pos, String dimensionId, String customName,
+                             String controllerBlockKey, String legacyTypeDisplay) {
         this.pos = pos;
         this.dimensionId = dimensionId;
-        this.customName = customName;
-        this.machineType = machineType;
+        this.customName = customName != null ? customName : "";
+        this.controllerBlockKey = controllerBlockKey != null ? controllerBlockKey : "";
+        this.legacyTypeDisplay = legacyTypeDisplay != null ? legacyTypeDisplay : "";
     }
 
     // ─── NBT ─────────────────────────────────────────────────────────────────
@@ -29,7 +41,10 @@ public class LinkedMachineData {
         tag.putInt("Z", pos.getZ());
         tag.putString("Dim", dimensionId);
         tag.putString("Name", customName);
-        tag.putString("Type", machineType);
+        tag.putString("BlockKey", controllerBlockKey);
+        if (!legacyTypeDisplay.isEmpty()) {
+            tag.putString("Type", legacyTypeDisplay);
+        }
         return tag;
     }
 
@@ -39,11 +54,23 @@ public class LinkedMachineData {
                 tag.getInt("Y"),
                 tag.getInt("Z")
         );
+        String blockKey = tag.contains("BlockKey") ? tag.getString("BlockKey") : "";
+        String legacyType = tag.getString("Type");
+        if (blockKey.isEmpty() && !legacyType.isEmpty()) {
+            return new LinkedMachineData(
+                    pos,
+                    tag.getString("Dim"),
+                    tag.getString("Name"),
+                    "",
+                    legacyType
+            );
+        }
         return new LinkedMachineData(
                 pos,
                 tag.getString("Dim"),
                 tag.getString("Name"),
-                tag.getString("Type")
+                blockKey,
+                ""
         );
     }
 
@@ -52,8 +79,45 @@ public class LinkedMachineData {
         return pos.equals(otherPos) && dimensionId.equals(otherDim);
     }
 
+    /**
+     * Localized controller name when no custom name is set; otherwise the custom name.
+     * Safe on dedicated server (uses block registry + translation keys).
+     */
+    public Component getDisplayNameComponent() {
+        if (customName != null && !customName.isBlank()) {
+            return Component.literal(customName);
+        }
+        if (controllerBlockKey != null && !controllerBlockKey.isBlank()) {
+            Block b = ForgeRegistries.BLOCKS.getValue(ResourceLocation.parse(controllerBlockKey));
+            if (b != null) {
+                return b.getName();
+            }
+        }
+        return Component.literal(legacyTypeDisplay != null ? legacyTypeDisplay : "");
+    }
+
+    /** For logging / plain string; prefer {@link #getDisplayNameComponent()} in UI. */
     public String getDisplayName() {
-        return customName.isBlank() ? machineType : customName;
+        return getDisplayNameComponent().getString();
+    }
+
+    /**
+     * Offline UI: custom name, block translation key, or legacy English from old saves.
+     */
+    public void applyToSnapshotIdentity(EnergySnapshot snap) {
+        snap.machineCustomName = customName != null ? customName : "";
+        snap.machineTypeKey = "";
+        if (controllerBlockKey != null && !controllerBlockKey.isBlank()) {
+            Block b = ForgeRegistries.BLOCKS.getValue(ResourceLocation.parse(controllerBlockKey));
+            if (b != null) {
+                snap.machineTypeKey = b.getDescriptionId();
+            }
+        }
+        if (snap.machineTypeKey.isEmpty()
+                && (snap.machineCustomName == null || snap.machineCustomName.isBlank())
+                && legacyTypeDisplay != null && !legacyTypeDisplay.isBlank()) {
+            snap.machineCustomName = legacyTypeDisplay;
+        }
     }
 
     public static String dimId(Level level) {
@@ -64,7 +128,7 @@ public class LinkedMachineData {
     public BlockPos getPos()          { return pos; }
     public String getDimensionId()    { return dimensionId; }
     public String getCustomName()     { return customName; }
-    public String getMachineType()    { return machineType; }
-    public void setCustomName(String n) { this.customName = n; }
-    public void setMachineType(String t) { this.machineType = t; }
+    public String getControllerBlockKey() { return controllerBlockKey; }
+    public String getLegacyTypeDisplay() { return legacyTypeDisplay; }
+    public void setCustomName(String n) { this.customName = n != null ? n : ""; }
 }

--- a/src/main/java/com/gtceuterminal/common/item/EnergyAnalyzerItem.java
+++ b/src/main/java/com/gtceuterminal/common/item/EnergyAnalyzerItem.java
@@ -23,12 +23,15 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,13 +61,10 @@ public class EnergyAnalyzerItem extends Item {
         if (machine == null) return InteractionResult.PASS;
 
         String dimId = LinkedMachineData.dimId(level);
-        String machineType = machine.getDefinition().getId().getPath()
-                .replace("_", " ")
-                .replace("/", " ");
-        // Capitalize first letter of each word
-        machineType = java.util.Arrays.stream(machineType.split(" "))
-                .map(w -> w.isEmpty() ? w : Character.toUpperCase(w.charAt(0)) + w.substring(1))
-                .reduce((a, b) -> a + " " + b).orElse(machineType);
+        Block ctrlBlock = level.getBlockState(pos).getBlock();
+        var blockRl = ForgeRegistries.BLOCKS.getKey(ctrlBlock);
+        String controllerBlockKey = blockRl != null ? blockRl.toString() : "";
+        Component controllerName = ctrlBlock.getName();
 
         if (player.isShiftKeyDown()) {
             // Shift+click: link or unlink
@@ -79,7 +79,7 @@ public class EnergyAnalyzerItem extends Item {
                     player.displayClientMessage(
                             Component.translatable(
                                     "item.gtceuterminal.energy_analyzer.message.unlinked",
-                                    machineType
+                                    controllerName
                             ),
                             true
                     );
@@ -113,12 +113,12 @@ public class EnergyAnalyzerItem extends Item {
             }
 
             // Link it
-            machines.add(new LinkedMachineData(pos, dimId, "", machineType));
+            machines.add(new LinkedMachineData(pos, dimId, "", controllerBlockKey));
             saveMachines(stack, machines);
             player.displayClientMessage(
                     Component.translatable(
                             "item.gtceuterminal.energy_analyzer.message.linked",
-                            machineType, machines.size(), max
+                            controllerName, machines.size(), max
                     ),
                     true
             );
@@ -217,7 +217,7 @@ public class EnergyAnalyzerItem extends Item {
             for (int i = 0; i < shown; i++) {
                 tooltip.add(Component.translatable(
                         "item.gtceuterminal.energy_analyzer.tooltip.machine_entry",
-                        machines.get(i).getDisplayName()
+                        machines.get(i).getDisplayNameComponent()
                 ));
             }
             if (machines.size() > 3) {

--- a/src/main/java/com/gtceuterminal/common/multiblock/ComponentType.java
+++ b/src/main/java/com/gtceuterminal/common/multiblock/ComponentType.java
@@ -125,6 +125,22 @@ public enum ComponentType {
         return Component.translatable(getDisplayNameKey());
     }
 
+    // ─── Coil tier localization helpers ──────────────────────────────────────
+    public static String getCoilTierName(int tier) {
+        String suffix = switch (tier) {
+            case 0 -> "cupronickel";
+            case 1 -> "kanthal";
+            case 2 -> "nichrome";
+            case 3 -> "rtm_alloy";
+            case 4 -> "hss_g";
+            case 5 -> "naquadah";
+            case 6 -> "trinium";
+            case 7 -> "tritanium";
+            default -> "unknown";
+        };
+        return Component.translatable("gui.gtceuterminal.coil_tier." + suffix).getString();
+    }
+
     public String getAbilityId() {
         return abilityId;
     }

--- a/src/main/java/com/gtceuterminal/common/multiblock/ComponentType.java
+++ b/src/main/java/com/gtceuterminal/common/multiblock/ComponentType.java
@@ -1,5 +1,7 @@
 package com.gtceuterminal.common.multiblock;
 
+import net.minecraft.network.chat.Component;
+
 // Types of multiblock components
 public enum ComponentType {
 
@@ -111,6 +113,16 @@ public enum ComponentType {
 
     public String getDisplayName() {
         return displayName;
+    }
+
+    /** Translation key for user-facing UI labels. */
+    public String getDisplayNameKey() {
+        return "component.gtceuterminal.component_type." + name().toLowerCase();
+    }
+
+    /** Localized name for UI usage (client-side). */
+    public Component getDisplayNameComponent() {
+        return Component.translatable(getDisplayNameKey());
     }
 
     public String getAbilityId() {

--- a/src/main/resources/assets/gtceuterminal/lang/de_de.json
+++ b/src/main/resources/assets/gtceuterminal/lang/de_de.json
@@ -239,6 +239,8 @@
   "gui.gtceuterminal.energy_analyzer.hatches_label": "Hatches:",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "IN",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "OUT",
+  "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
+  "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s more...",
 
   "gui.gtceuterminal.energy_analyzer.graph_header": "History (EU/s):",

--- a/src/main/resources/assets/gtceuterminal/lang/de_de.json
+++ b/src/main/resources/assets/gtceuterminal/lang/de_de.json
@@ -42,7 +42,6 @@
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_open": "§7Right-click: §bOpen on that machine",
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_air_open": "§7Right-click (air): §bOpen list",
   "item.gtceuterminal.energy_analyzer.tooltip.shift_right_click_manage": "§7Shift + Right-click: §eLink / Unlink machine",
-
   "item.gtceuterminal.energy_analyzer.message.unlinked": "§cUnlinked: §f%s",
   "item.gtceuterminal.energy_analyzer.message.cannot_link_more": "§cCannot link more than §f%d§c machines. Unlink one first.",
   "item.gtceuterminal.energy_analyzer.message.dimension_not_allowed": "§cDimension §f%s§c is not allowed in config.",
@@ -93,7 +92,6 @@
   "item.gtceuterminal.tooltip.me_range.out_of_range": "  §c● Out of Range",
 
   "item.gtceuterminal.multi_structure_manager.behavior.linked_to_me_network": "§a✓ Linked to ME Network",
-
   "item.gtceuterminal.multi_structure_manager.behavior.cooldown_active": "§cCooldown active!",
   "item.gtceuterminal.multi_structure_manager.behavior.multiblock_built": "§aMultiblock built!",
   "item.gtceuterminal.multi_structure_manager.behavior.failed_to_build_check_materials": "§cFailed to build! Check materials.",
@@ -110,6 +108,7 @@
   "item.gtceuterminal.schematic_paster.paste_success.no_skipped": "§aSchematic pasted! §f%d blocks placed",
   "item.gtceuterminal.schematic_paster.paste_success.with_skipped": "§aSchematic pasted! §f%d blocks placed §7(%d skipped)",
   "item.gtceuterminal.schematic_paster.missing_materials": "§cMissing materials: §f%s",
+
   "item.gtceuterminal.power_logger.desc": "Monitors machine power consumption",
 
   "gui.gtceuterminal.planner.title": "§f§lPlacement Planner",
@@ -152,7 +151,6 @@
   "gui.gtceuterminal.blueprint.library.feedback.failed_delete": "§cFailed to delete.",
   "gui.gtceuterminal.blueprint.library.feedback.saved_as": "§aSaved as: %s",
   "gui.gtceuterminal.blueprint.library.feedback.failed_save": "§cFailed to save.",
-
   "gui.gtceuterminal.blueprint.view.title": "Blueprint Viewer",
   "gui.gtceuterminal.blueprint.view.orbit.hints": "§7[Drag] Orbit  [Scroll] Zoom  [Tab] Place Mode  [Esc] Back to Planner",
   "gui.gtceuterminal.blueprint.view.orbit.place_mode": "§9Place Mode",
@@ -174,19 +172,16 @@
   "gui.gtceuterminal.schematic_interface.hint_formed_2": "§8multiblock to copy it",
   "gui.gtceuterminal.schematic_interface.selected": "§7Selected: §f%s",
   "gui.gtceuterminal.schematic_interface.entry.blocks": "§8%s blocks",
-
   "gui.gtceuterminal.schematic_interface.preview.clipboard_content": "§7Clipboard content:",
   "gui.gtceuterminal.schematic_interface.preview.save_to_see": "§8Save it to see preview",
   "gui.gtceuterminal.schematic_interface.preview.no_preview": "§7No preview",
   "gui.gtceuterminal.schematic_interface.preview.info": "§7%s blocks | %sx%sx%s",
   "gui.gtceuterminal.schematic_interface.preview.zoom_hint": "§8Ctrl + Mouse wheel for zoom",
   "gui.gtceuterminal.schematic_interface.preview.rotation_hint": "§8Mouse wheel to rotate preview",
-
   "gui.gtceuterminal.schematic_interface.button.save": "§f§lSave",
   "gui.gtceuterminal.schematic_interface.button.load": "§f§lLoad",
   "gui.gtceuterminal.schematic_interface.button.delete": "§f§lDelete",
   "gui.gtceuterminal.schematic_interface.button.close": "§7Close",
-
   "gui.gtceuterminal.schematic_interface.chat.error.no_clipboard": "§c§lError: §cNo clipboard! Copy a multiblock first.",
   "gui.gtceuterminal.schematic_interface.chat.error.enter_name": "§c§lError: §cPlease enter a name!",
   "gui.gtceuterminal.schematic_interface.chat.error.reserved_name": "§c§lError: §c'Clipboard' is a reserved name!",
@@ -195,7 +190,6 @@
   "gui.gtceuterminal.schematic_interface.chat.error.no_schematic_selected": "§c§lError: §cNo schematic selected!",
   "gui.gtceuterminal.schematic_interface.chat.success.loaded_to_clipboard": "§a§l✓ §aLoaded to clipboard: §f%s",
   "gui.gtceuterminal.schematic_interface.chat.success.deleted": "§c§l✗ §cDeleted: §f%s",
-
   "gui.gtceuterminal.schematic_interface.fallback.multiblock_structure": "Multiblock Structure",
 
   "gui.gtceuterminal.multiblock_manager.nearby_title": "Nearby Multiblocks (%s)",
@@ -231,44 +225,36 @@
   "gui.gtceuterminal.energy_analyzer.out_line": "Out: %s/t  (%s/s)",
   "gui.gtceuterminal.energy_analyzer.net_line": "Net: %s/s",
   "gui.gtceuterminal.energy_analyzer.voltage_line": "Voltage: %s (%sV)  %sA max",
-
   "gui.gtceuterminal.energy_analyzer.recipe_button": "§6Recipe: §7[log ▶]",
   "gui.gtceuterminal.energy_analyzer.recipe_time_left": "%s left",
   "gui.gtceuterminal.energy_analyzer.recipe_finishing": "finishing...",
-
   "gui.gtceuterminal.energy_analyzer.hatches_label": "Hatches:",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "IN",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "OUT",
   "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
   "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s more...",
-
   "gui.gtceuterminal.energy_analyzer.graph_header": "History (EU/s):",
   "gui.gtceuterminal.energy_analyzer.legend_in": "— In",
   "gui.gtceuterminal.energy_analyzer.legend_out": "— Out",
-
   "gui.gtceuterminal.energy_analyzer.machine_options.title": "§6Machine Options",
   "gui.gtceuterminal.energy_analyzer.machine_options.rename": "§e✎  Rename",
   "gui.gtceuterminal.energy_analyzer.machine_options.unlink_machine": "§c✖  Unlink machine",
   "gui.gtceuterminal.energy_analyzer.machine_options.cancel": "§7Cancel",
-
   "gui.gtceuterminal.energy_analyzer.rename_dialog.title": "§6Rename Machine",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.confirm": "§aConfirm",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.cancel": "§7Cancel",
-
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.title": "§cUnlink Machine",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.remove_prompt": "§7Remove §f%s§7?",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.unlink": "§cUnlink",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.cancel": "§7Cancel",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.hint_click_outside_cancel": "§8Click outside to cancel",
-
   "gui.gtceuterminal.energy_analyzer.recipe_log.title": "§6Recipe Log  §7— %s",
   "gui.gtceuterminal.energy_analyzer.recipe_log.output": "§7Output",
   "gui.gtceuterminal.energy_analyzer.recipe_log.time": "§7Time",
   "gui.gtceuterminal.energy_analyzer.recipe_log.when": "§7When",
   "gui.gtceuterminal.energy_analyzer.recipe_log.no_recipes": "§7No recipes recorded yet.",
   "gui.gtceuterminal.energy_analyzer.recipe_log.hint_click_outside_close": "§8Click outside to close",
-
   "gui.gtceuterminal.energy_analyzer.mode.not_formed": "[NOT FORMED]",
   "gui.gtceuterminal.energy_analyzer.mode.consumer": "[Consumer]",
   "gui.gtceuterminal.energy_analyzer.mode.generator": "[Generator]",
@@ -276,59 +262,46 @@
   "gui.gtceuterminal.energy_analyzer.mode.unknown": "[Unknown]",
 
   "gui.gtceuterminal.manager_settings.title": "§lManager Settings",
-
   "gui.gtceuterminal.manager_settings.common.yes": "§aYes",
   "gui.gtceuterminal.manager_settings.common.no": "§cNo",
-
   "gui.gtceuterminal.manager_settings.hatch_mode.label": "§7No Hatch Mode",
   "gui.gtceuterminal.manager_settings.hatch_mode.tooltip": "§7Build without hatches",
   "gui.gtceuterminal.manager_settings.hatch_mode.hint_toggle": "§8← Click to toggle",
-
   "gui.gtceuterminal.manager_settings.tier_mode.label": "§7Tier Mode",
   "gui.gtceuterminal.manager_settings.tier_mode.tooltip": "§7Component tier (1=LV, 2=MV, ...)",
   "gui.gtceuterminal.manager_settings.tier_mode.hint_scroll_type": "§8↑↓ Scroll or type",
-
   "gui.gtceuterminal.manager_settings.repeat_count.label": "§7Repeat Count",
   "gui.gtceuterminal.manager_settings.repeat_count.tooltip": "§7Number of times to repeat the structure",
   "gui.gtceuterminal.manager_settings.repeat_count.hint_layers": "§8Repeatable layers (0-99)",
-
   "gui.gtceuterminal.manager_settings.use_ae2.label": "§7Use AE2",
   "gui.gtceuterminal.manager_settings.use_ae2.tooltip": "§7Wireless Terminal is required",
   "gui.gtceuterminal.manager_settings.use_ae2.hint_use_materials": "§8← Use AE2 for materials",
 
   "gui.gtceuterminal.component_detail.header.title_compact": "§l§f%s",
   "gui.gtceuterminal.component_detail.header.title_full": "§l§f%s - Components",
-
   "gui.gtceuterminal.component_detail.info.multiblock": "§7Multiblock: §f%s",
   "gui.gtceuterminal.component_detail.info.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail.info.distance": "§7Distance: §f%s",
   "gui.gtceuterminal.component_detail.info.components": "§7Components: §f%s §7(§f%s §7groups)",
-
   "gui.gtceuterminal.component_detail.list.header": "§l§7Component Groups:",
-
   "gui.gtceuterminal.component_detail.entry.count": "§7Count: §f%s",
   "gui.gtceuterminal.component_detail.entry.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail.entry.upgrade": "§aUpgrade",
   "gui.gtceuterminal.component_detail.entry.max": "§7Max",
-
   "gui.gtceuterminal.component_detail.actions.bulk_upgrade": "§aBulk Upgrade",
   "gui.gtceuterminal.component_detail.actions.scan": "§7Scan",
   "gui.gtceuterminal.component_detail.actions.back": "§7← Back",
-
   "gui.gtceuterminal.component_detail.notifications.bulk_not_implemented": "§7Bulk upgrade not yet implemented",
   "gui.gtceuterminal.component_detail.notifications.rescanned": "§aRescanned components",
   "gui.gtceuterminal.component_detail.notifications.use_esc_to_close": "§7Use ESC to close",
 
   "gui.gtceuterminal.component_detail_dialog.unknown_multiblock": "Unknown Multiblock",
   "gui.gtceuterminal.component_detail_dialog.header.title": "§l§f%s - Components",
-
   "gui.gtceuterminal.component_detail_dialog.info.multiblock": "§7Multiblock: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.distance": "§7Distance: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.components": "§7Components: §f%s §7(§f%s §7groups)",
-
   "gui.gtceuterminal.component_detail_dialog.list.header": "§l§7Component Groups:",
-
   "gui.gtceuterminal.component_detail_dialog.entry.count": "§7Count: §f%s",
   "gui.gtceuterminal.component_detail_dialog.entry.tier": "§7Tier: §f%s",
 
@@ -345,50 +318,84 @@
 
   "gui.gtceuterminal.component_upgrade_dialog.title": "§l§fUpgrade %s",
 
+  "component.gtceuterminal.component_type.energy_hatch": "Energy Hatch",
+  "component.gtceuterminal.component_type.dynamo_hatch": "Dynamo Hatch",
+  "component.gtceuterminal.component_type.wireless_energy_input": "Wireless Energy Input Hatch",
+  "component.gtceuterminal.component_type.wireless_energy_output": "Wireless Energy Output Hatch",
+  "component.gtceuterminal.component_type.wireless_laser_input": "Wireless Laser Target Hatch",
+  "component.gtceuterminal.component_type.wireless_laser_output": "Wireless Laser Source Hatch",
+  "component.gtceuterminal.component_type.substation_input_energy": "Substation Input Energy",
+  "component.gtceuterminal.component_type.substation_output_energy": "Substation Output Energy",
+  "component.gtceuterminal.component_type.input_bus": "Input Bus",
+  "component.gtceuterminal.component_type.output_bus": "Output Bus",
+  "component.gtceuterminal.component_type.steam_input_bus": "Steam Input Bus",
+  "component.gtceuterminal.component_type.steam_output_bus": "Steam Output Bus",
+  "component.gtceuterminal.component_type.input_hatch": "Input Hatch",
+  "component.gtceuterminal.component_type.output_hatch": "Output Hatch",
+  "component.gtceuterminal.component_type.input_hatch_1x": "Input Hatch (1x)",
+  "component.gtceuterminal.component_type.output_hatch_1x": "Output Hatch (1x)",
+  "component.gtceuterminal.component_type.quad_input_hatch": "Quad Input Hatch (4x)",
+  "component.gtceuterminal.component_type.quad_output_hatch": "Quad Output Hatch (4x)",
+  "component.gtceuterminal.component_type.nonuple_input_hatch": "Nonuple Input Hatch (9x)",
+  "component.gtceuterminal.component_type.nonuple_output_hatch": "Nonuple Output Hatch (9x)",
+  "component.gtceuterminal.component_type.muffler": "Muffler Hatch",
+  "component.gtceuterminal.component_type.maintenance": "Maintenance Hatch",
+  "component.gtceuterminal.component_type.rotor_holder": "Rotor Holder",
+  "component.gtceuterminal.component_type.pump_fluid_hatch": "Pump Fluid Hatch",
+  "component.gtceuterminal.component_type.steam": "Steam Hatch",
+  "component.gtceuterminal.component_type.tank_valve": "Tank Valve",
+  "component.gtceuterminal.component_type.passthrough_hatch": "Passthrough Hatch",
+  "component.gtceuterminal.component_type.parallel_hatch": "Parallel Hatch",
+  "component.gtceuterminal.component_type.input_laser": "Input Laser Hatch",
+  "component.gtceuterminal.component_type.output_laser": "Output Laser Hatch",
+  "component.gtceuterminal.component_type.computation_data_reception": "Computation Data Reception Hatch",
+  "component.gtceuterminal.component_type.computation_data_transmission": "Computation Data Transmission Hatch",
+  "component.gtceuterminal.component_type.optical_data_reception": "Optical Data Reception Hatch",
+  "component.gtceuterminal.component_type.optical_data_transmission": "Optical Data Transmission Hatch",
+  "component.gtceuterminal.component_type.data_access": "Data Access Hatch",
+  "component.gtceuterminal.component_type.hpca_component": "HPCA Component",
+  "component.gtceuterminal.component_type.object_holder": "Object Holder",
+  "component.gtceuterminal.component_type.coil": "Heating Coil",
+  "component.gtceuterminal.component_type.casing": "Casing",
+  "component.gtceuterminal.component_type.machine_hatch": "Machine Hatch",
+  "component.gtceuterminal.component_type.dual_hatch": "Dual Hatch",
+  "component.gtceuterminal.component_type.filter": "Filter",
+  "component.gtceuterminal.component_type.unknown": "Unknown Component",
+
   "gui.gtceuterminal.component_upgrade_dialog.info.count_components": "§7Count: §f%s components",
   "gui.gtceuterminal.component_upgrade_dialog.info.current_tier": "§7Current Tier: §f%s",
-
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_upgrade_option": "§l§7Select Upgrade Option:",
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_target_tier": "§l§7Select Target Tier:",
-
   "gui.gtceuterminal.component_upgrade_dialog.actions.confirm_change": "§eConfirm Change",
   "gui.gtceuterminal.component_upgrade_dialog.actions.auto_craft": "§9⚙ Auto-craft",
   "gui.gtceuterminal.component_upgrade_dialog.actions.cancel": "§fCancel",
-
   "gui.gtceuterminal.component_upgrade_dialog.chat.select_upgrade_option_first": "§eSelect an upgrade option first.",
   "gui.gtceuterminal.component_upgrade_dialog.chat.analyzing_me_network": "§7Analyzing ME Network...",
   "gui.gtceuterminal.component_upgrade_dialog.chat.changing_components": "§aChanging %s components...",
-
   "gui.gtceuterminal.component_upgrade_dialog.materials.required_label": "§l§7Required Materials:",
   "gui.gtceuterminal.component_upgrade_dialog.materials.me_materials_verified": "§e⚠ ME materials will be verified on confirmation",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode": "§a§lCREATIVE MODE",
   "gui.gtceuterminal.component_upgrade_dialog.materials.select_option_to_see": "§7Select an option to see materials",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode_not_required": "§a[Creative Mode - Not Required]",
-
   "gui.gtceuterminal.component_upgrade_dialog.option_all_any": "§fALL\n§7(any)",
 
   "gui.gtceuterminal.material_list.quantity.me": "§a%s§7/%s §a[ME]",
   "gui.gtceuterminal.material_list.quantity.inv": "§7%s/%s [Inv]",
   "gui.gtceuterminal.material_list.quantity.mix": "§e%s§7/%s §e[Mix]",
   "gui.gtceuterminal.material_list.quantity.missing": "§c%s§7/%s §c[-%s]",
-
   "gui.gtceuterminal.material_list.tooltip.required": "§7Required: §f%s",
   "gui.gtceuterminal.material_list.tooltip.available_colored": "§7Available: %s",
   "gui.gtceuterminal.material_list.tooltip.sources_header": "§7§l--- Sources ---",
-
   "gui.gtceuterminal.material_list.tooltip.source.inventory_nonzero": "  §7Inventory: §f%s",
   "gui.gtceuterminal.material_list.tooltip.source.inventory_zero": "  §8Inventory: 0",
   "gui.gtceuterminal.material_list.tooltip.source.chests_nonzero": "  §7Chests: §f%s",
   "gui.gtceuterminal.material_list.tooltip.source.chests_zero": "  §8Chests: 0",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_nonzero": "  §e§lME Network: §f%s §8(pending verification)",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_zero": "  §8ME Network: 0",
-
   "gui.gtceuterminal.material_list.tooltip.status.sufficient": "§a✓ Sufficient materials",
   "gui.gtceuterminal.material_list.tooltip.status.missing": "§c✗ Missing %s items",
-
   "gui.gtceuterminal.material_list.tooltip.primary_source.me_pending": "§7Primary source: %s §8(will verify on confirm)",
   "gui.gtceuterminal.material_list.tooltip.primary_source.normal": "§7Primary source: %s",
-
   "gui.gtceuterminal.material_list.source.me_network": "ME Network",
   "gui.gtceuterminal.material_list.source.inventory": "Inventory",
   "gui.gtceuterminal.material_list.source.chests": "Chests",
@@ -405,7 +412,6 @@
   "gui.gtceuterminal.theme_editor.style.gtceu_native": "GTCEu Native",
   "gui.gtceuterminal.theme_editor.style.dark": "Dark",
   "gui.gtceuterminal.theme_editor.style_label": "§7Style: §f%s",
-
   "gui.gtceuterminal.theme_editor.wallpaper": "§7Wallpaper",
   "gui.gtceuterminal.theme_editor.none": "§8None",
   "gui.gtceuterminal.theme_editor.preview": "§7Preview",
@@ -413,15 +419,12 @@
   "gui.gtceuterminal.theme_editor.tab.accent": "Accent",
   "gui.gtceuterminal.theme_editor.tab.bg": "BG",
   "gui.gtceuterminal.theme_editor.tab.panel": "Panel",
-
   "gui.gtceuterminal.theme_editor.options": "§7Options",
   "gui.gtceuterminal.theme_editor.toggle.compact_mode": "Compact mode",
   "gui.gtceuterminal.theme_editor.toggle.show_tooltips": "Show tooltips",
   "gui.gtceuterminal.theme_editor.toggle.show_borders": "Show borders",
-
   "gui.gtceuterminal.theme_editor.button.save": "§aSave",
   "gui.gtceuterminal.theme_editor.button.reset": "§cReset",
-
   "gui.gtceuterminal.theme_editor.preset.default": "Default",
   "gui.gtceuterminal.theme_editor.preset.gtceu_red": "GTCEu Red",
   "gui.gtceuterminal.theme_editor.preset.matrix": "Matrix",

--- a/src/main/resources/assets/gtceuterminal/lang/en_us.json
+++ b/src/main/resources/assets/gtceuterminal/lang/en_us.json
@@ -239,6 +239,8 @@
   "gui.gtceuterminal.energy_analyzer.hatches_label": "Hatches:",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "IN",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "OUT",
+  "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
+  "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s more...",
 
   "gui.gtceuterminal.energy_analyzer.graph_header": "History (EU/s):",

--- a/src/main/resources/assets/gtceuterminal/lang/en_us.json
+++ b/src/main/resources/assets/gtceuterminal/lang/en_us.json
@@ -42,7 +42,6 @@
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_open": "§7Right-click: §bOpen on that machine",
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_air_open": "§7Right-click (air): §bOpen list",
   "item.gtceuterminal.energy_analyzer.tooltip.shift_right_click_manage": "§7Shift + Right-click: §eLink / Unlink machine",
-
   "item.gtceuterminal.energy_analyzer.message.unlinked": "§cUnlinked: §f%s",
   "item.gtceuterminal.energy_analyzer.message.cannot_link_more": "§cCannot link more than §f%d§c machines. Unlink one first.",
   "item.gtceuterminal.energy_analyzer.message.dimension_not_allowed": "§cDimension §f%s§c is not allowed in config.",
@@ -93,7 +92,6 @@
   "item.gtceuterminal.tooltip.me_range.out_of_range": "  §c● Out of Range",
 
   "item.gtceuterminal.multi_structure_manager.behavior.linked_to_me_network": "§a✓ Linked to ME Network",
-
   "item.gtceuterminal.multi_structure_manager.behavior.cooldown_active": "§cCooldown active!",
   "item.gtceuterminal.multi_structure_manager.behavior.multiblock_built": "§aMultiblock built!",
   "item.gtceuterminal.multi_structure_manager.behavior.failed_to_build_check_materials": "§cFailed to build! Check materials.",
@@ -110,6 +108,7 @@
   "item.gtceuterminal.schematic_paster.paste_success.no_skipped": "§aSchematic pasted! §f%d blocks placed",
   "item.gtceuterminal.schematic_paster.paste_success.with_skipped": "§aSchematic pasted! §f%d blocks placed §7(%d skipped)",
   "item.gtceuterminal.schematic_paster.missing_materials": "§cMissing materials: §f%s",
+
   "item.gtceuterminal.power_logger.desc": "Monitors machine power consumption",
 
   "gui.gtceuterminal.planner.title": "§f§lPlacement Planner",
@@ -152,7 +151,6 @@
   "gui.gtceuterminal.blueprint.library.feedback.failed_delete": "§cFailed to delete.",
   "gui.gtceuterminal.blueprint.library.feedback.saved_as": "§aSaved as: %s",
   "gui.gtceuterminal.blueprint.library.feedback.failed_save": "§cFailed to save.",
-
   "gui.gtceuterminal.blueprint.view.title": "Blueprint Viewer",
   "gui.gtceuterminal.blueprint.view.orbit.hints": "§7[Drag] Orbit  [Scroll] Zoom  [Tab] Place Mode  [Esc] Back to Planner",
   "gui.gtceuterminal.blueprint.view.orbit.place_mode": "§9Place Mode",
@@ -174,19 +172,16 @@
   "gui.gtceuterminal.schematic_interface.hint_formed_2": "§8multiblock to copy it",
   "gui.gtceuterminal.schematic_interface.selected": "§7Selected: §f%s",
   "gui.gtceuterminal.schematic_interface.entry.blocks": "§8%s blocks",
-
   "gui.gtceuterminal.schematic_interface.preview.clipboard_content": "§7Clipboard content:",
   "gui.gtceuterminal.schematic_interface.preview.save_to_see": "§8Save it to see preview",
   "gui.gtceuterminal.schematic_interface.preview.no_preview": "§7No preview",
   "gui.gtceuterminal.schematic_interface.preview.info": "§7%s blocks | %sx%sx%s",
   "gui.gtceuterminal.schematic_interface.preview.zoom_hint": "§8Ctrl + Mouse wheel for zoom",
   "gui.gtceuterminal.schematic_interface.preview.rotation_hint": "§8Mouse wheel to rotate preview",
-
   "gui.gtceuterminal.schematic_interface.button.save": "§f§lSave",
   "gui.gtceuterminal.schematic_interface.button.load": "§f§lLoad",
   "gui.gtceuterminal.schematic_interface.button.delete": "§f§lDelete",
   "gui.gtceuterminal.schematic_interface.button.close": "§7Close",
-
   "gui.gtceuterminal.schematic_interface.chat.error.no_clipboard": "§c§lError: §cNo clipboard! Copy a multiblock first.",
   "gui.gtceuterminal.schematic_interface.chat.error.enter_name": "§c§lError: §cPlease enter a name!",
   "gui.gtceuterminal.schematic_interface.chat.error.reserved_name": "§c§lError: §c'Clipboard' is a reserved name!",
@@ -195,7 +190,6 @@
   "gui.gtceuterminal.schematic_interface.chat.error.no_schematic_selected": "§c§lError: §cNo schematic selected!",
   "gui.gtceuterminal.schematic_interface.chat.success.loaded_to_clipboard": "§a§l✓ §aLoaded to clipboard: §f%s",
   "gui.gtceuterminal.schematic_interface.chat.success.deleted": "§c§l✗ §cDeleted: §f%s",
-
   "gui.gtceuterminal.schematic_interface.fallback.multiblock_structure": "Multiblock Structure",
 
   "gui.gtceuterminal.multiblock_manager.nearby_title": "Nearby Multiblocks (%s)",
@@ -231,44 +225,36 @@
   "gui.gtceuterminal.energy_analyzer.out_line": "Out: %s/t  (%s/s)",
   "gui.gtceuterminal.energy_analyzer.net_line": "Net: %s/s",
   "gui.gtceuterminal.energy_analyzer.voltage_line": "Voltage: %s (%sV)  %sA max",
-
   "gui.gtceuterminal.energy_analyzer.recipe_button": "§6Recipe: §7[log ▶]",
   "gui.gtceuterminal.energy_analyzer.recipe_time_left": "%s left",
   "gui.gtceuterminal.energy_analyzer.recipe_finishing": "finishing...",
-
   "gui.gtceuterminal.energy_analyzer.hatches_label": "Hatches:",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "IN",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "OUT",
   "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
   "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s more...",
-
   "gui.gtceuterminal.energy_analyzer.graph_header": "History (EU/s):",
   "gui.gtceuterminal.energy_analyzer.legend_in": "— In",
   "gui.gtceuterminal.energy_analyzer.legend_out": "— Out",
-
   "gui.gtceuterminal.energy_analyzer.machine_options.title": "§6Machine Options",
   "gui.gtceuterminal.energy_analyzer.machine_options.rename": "§e✎  Rename",
   "gui.gtceuterminal.energy_analyzer.machine_options.unlink_machine": "§c✖  Unlink machine",
   "gui.gtceuterminal.energy_analyzer.machine_options.cancel": "§7Cancel",
-
   "gui.gtceuterminal.energy_analyzer.rename_dialog.title": "§6Rename Machine",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.confirm": "§aConfirm",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.cancel": "§7Cancel",
-
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.title": "§cUnlink Machine",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.remove_prompt": "§7Remove §f%s§7?",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.unlink": "§cUnlink",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.cancel": "§7Cancel",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.hint_click_outside_cancel": "§8Click outside to cancel",
-
   "gui.gtceuterminal.energy_analyzer.recipe_log.title": "§6Recipe Log  §7— %s",
   "gui.gtceuterminal.energy_analyzer.recipe_log.output": "§7Output",
   "gui.gtceuterminal.energy_analyzer.recipe_log.time": "§7Time",
   "gui.gtceuterminal.energy_analyzer.recipe_log.when": "§7When",
   "gui.gtceuterminal.energy_analyzer.recipe_log.no_recipes": "§7No recipes recorded yet.",
   "gui.gtceuterminal.energy_analyzer.recipe_log.hint_click_outside_close": "§8Click outside to close",
-
   "gui.gtceuterminal.energy_analyzer.mode.not_formed": "[NOT FORMED]",
   "gui.gtceuterminal.energy_analyzer.mode.consumer": "[Consumer]",
   "gui.gtceuterminal.energy_analyzer.mode.generator": "[Generator]",
@@ -276,59 +262,46 @@
   "gui.gtceuterminal.energy_analyzer.mode.unknown": "[Unknown]",
 
   "gui.gtceuterminal.manager_settings.title": "§lManager Settings",
-
   "gui.gtceuterminal.manager_settings.common.yes": "§aYes",
   "gui.gtceuterminal.manager_settings.common.no": "§cNo",
-
   "gui.gtceuterminal.manager_settings.hatch_mode.label": "§7No Hatch Mode",
   "gui.gtceuterminal.manager_settings.hatch_mode.tooltip": "§7Build without hatches",
   "gui.gtceuterminal.manager_settings.hatch_mode.hint_toggle": "§8← Click to toggle",
-
   "gui.gtceuterminal.manager_settings.tier_mode.label": "§7Tier Mode",
   "gui.gtceuterminal.manager_settings.tier_mode.tooltip": "§7Component tier (1=LV, 2=MV, ...)",
   "gui.gtceuterminal.manager_settings.tier_mode.hint_scroll_type": "§8↑↓ Scroll or type",
-
   "gui.gtceuterminal.manager_settings.repeat_count.label": "§7Repeat Count",
   "gui.gtceuterminal.manager_settings.repeat_count.tooltip": "§7Number of times to repeat the structure",
   "gui.gtceuterminal.manager_settings.repeat_count.hint_layers": "§8Repeatable layers (0-99)",
-
   "gui.gtceuterminal.manager_settings.use_ae2.label": "§7Use AE2",
   "gui.gtceuterminal.manager_settings.use_ae2.tooltip": "§7Wireless Terminal is required",
   "gui.gtceuterminal.manager_settings.use_ae2.hint_use_materials": "§8← Use AE2 for materials",
 
   "gui.gtceuterminal.component_detail.header.title_compact": "§l§f%s",
   "gui.gtceuterminal.component_detail.header.title_full": "§l§f%s - Components",
-
   "gui.gtceuterminal.component_detail.info.multiblock": "§7Multiblock: §f%s",
   "gui.gtceuterminal.component_detail.info.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail.info.distance": "§7Distance: §f%s",
   "gui.gtceuterminal.component_detail.info.components": "§7Components: §f%s §7(§f%s §7groups)",
-
   "gui.gtceuterminal.component_detail.list.header": "§l§7Component Groups:",
-
   "gui.gtceuterminal.component_detail.entry.count": "§7Count: §f%s",
   "gui.gtceuterminal.component_detail.entry.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail.entry.upgrade": "§aUpgrade",
   "gui.gtceuterminal.component_detail.entry.max": "§7Max",
-
   "gui.gtceuterminal.component_detail.actions.bulk_upgrade": "§aBulk Upgrade",
   "gui.gtceuterminal.component_detail.actions.scan": "§7Scan",
   "gui.gtceuterminal.component_detail.actions.back": "§7← Back",
-
   "gui.gtceuterminal.component_detail.notifications.bulk_not_implemented": "§7Bulk upgrade not yet implemented",
   "gui.gtceuterminal.component_detail.notifications.rescanned": "§aRescanned components",
   "gui.gtceuterminal.component_detail.notifications.use_esc_to_close": "§7Use ESC to close",
 
   "gui.gtceuterminal.component_detail_dialog.unknown_multiblock": "Unknown Multiblock",
   "gui.gtceuterminal.component_detail_dialog.header.title": "§l§f%s - Components",
-
   "gui.gtceuterminal.component_detail_dialog.info.multiblock": "§7Multiblock: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.distance": "§7Distance: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.components": "§7Components: §f%s §7(§f%s §7groups)",
-
   "gui.gtceuterminal.component_detail_dialog.list.header": "§l§7Component Groups:",
-
   "gui.gtceuterminal.component_detail_dialog.entry.count": "§7Count: §f%s",
   "gui.gtceuterminal.component_detail_dialog.entry.tier": "§7Tier: §f%s",
 
@@ -336,6 +309,7 @@
   "gui.gtceuterminal.group_upgrade_dialog.upgrade_x": "§eUpgrade %sx %s",
   "gui.gtceuterminal.group_upgrade_dialog.from": "§7From: §f%s",
   "gui.gtceuterminal.group_upgrade_dialog.to": "§7To: §f%s",
+  "gui.gtceuterminal.group_upgrade_dialog.type_with_tier": "%s (%s)",
   "gui.gtceuterminal.group_upgrade_dialog.creative_no_materials": "§aCreative Mode - No materials required",
   "gui.gtceuterminal.group_upgrade_dialog.required_materials": "§7Required materials:",
   "gui.gtceuterminal.group_upgrade_dialog.confirm_upgrade_all": "Upgrade All (%s)",
@@ -343,52 +317,96 @@
   "gui.gtceuterminal.group_upgrade_dialog.cancel": "Cancel",
   "gui.gtceuterminal.group_upgrade_dialog.unknown_coil": "Unknown Coil",
 
+  "gui.gtceuterminal.coil_tier.cupronickel": "Cupronickel",
+  "gui.gtceuterminal.coil_tier.kanthal": "Kanthal",
+  "gui.gtceuterminal.coil_tier.nichrome": "Nichrome",
+  "gui.gtceuterminal.coil_tier.rtm_alloy": "RTM Alloy",
+  "gui.gtceuterminal.coil_tier.hss_g": "HSS-G",
+  "gui.gtceuterminal.coil_tier.naquadah": "Naquadah",
+  "gui.gtceuterminal.coil_tier.trinium": "Trinium",
+  "gui.gtceuterminal.coil_tier.tritanium": "Tritanium",
+  "gui.gtceuterminal.coil_tier.unknown": "Unknown Coil",
+
   "gui.gtceuterminal.component_upgrade_dialog.title": "§l§fUpgrade %s",
+
+  "component.gtceuterminal.component_type.energy_hatch": "Energy Hatch",
+  "component.gtceuterminal.component_type.dynamo_hatch": "Dynamo Hatch",
+  "component.gtceuterminal.component_type.wireless_energy_input": "Wireless Energy Input Hatch",
+  "component.gtceuterminal.component_type.wireless_energy_output": "Wireless Energy Output Hatch",
+  "component.gtceuterminal.component_type.wireless_laser_input": "Wireless Laser Target Hatch",
+  "component.gtceuterminal.component_type.wireless_laser_output": "Wireless Laser Source Hatch",
+  "component.gtceuterminal.component_type.substation_input_energy": "Substation Input Energy",
+  "component.gtceuterminal.component_type.substation_output_energy": "Substation Output Energy",
+  "component.gtceuterminal.component_type.input_bus": "Input Bus",
+  "component.gtceuterminal.component_type.output_bus": "Output Bus",
+  "component.gtceuterminal.component_type.steam_input_bus": "Steam Input Bus",
+  "component.gtceuterminal.component_type.steam_output_bus": "Steam Output Bus",
+  "component.gtceuterminal.component_type.input_hatch": "Input Hatch",
+  "component.gtceuterminal.component_type.output_hatch": "Output Hatch",
+  "component.gtceuterminal.component_type.input_hatch_1x": "Input Hatch (1x)",
+  "component.gtceuterminal.component_type.output_hatch_1x": "Output Hatch (1x)",
+  "component.gtceuterminal.component_type.quad_input_hatch": "Quad Input Hatch (4x)",
+  "component.gtceuterminal.component_type.quad_output_hatch": "Quad Output Hatch (4x)",
+  "component.gtceuterminal.component_type.nonuple_input_hatch": "Nonuple Input Hatch (9x)",
+  "component.gtceuterminal.component_type.nonuple_output_hatch": "Nonuple Output Hatch (9x)",
+  "component.gtceuterminal.component_type.muffler": "Muffler Hatch",
+  "component.gtceuterminal.component_type.maintenance": "Maintenance Hatch",
+  "component.gtceuterminal.component_type.rotor_holder": "Rotor Holder",
+  "component.gtceuterminal.component_type.pump_fluid_hatch": "Pump Fluid Hatch",
+  "component.gtceuterminal.component_type.steam": "Steam Hatch",
+  "component.gtceuterminal.component_type.tank_valve": "Tank Valve",
+  "component.gtceuterminal.component_type.passthrough_hatch": "Passthrough Hatch",
+  "component.gtceuterminal.component_type.parallel_hatch": "Parallel Hatch",
+  "component.gtceuterminal.component_type.input_laser": "Input Laser Hatch",
+  "component.gtceuterminal.component_type.output_laser": "Output Laser Hatch",
+  "component.gtceuterminal.component_type.computation_data_reception": "Computation Data Reception Hatch",
+  "component.gtceuterminal.component_type.computation_data_transmission": "Computation Data Transmission Hatch",
+  "component.gtceuterminal.component_type.optical_data_reception": "Optical Data Reception Hatch",
+  "component.gtceuterminal.component_type.optical_data_transmission": "Optical Data Transmission Hatch",
+  "component.gtceuterminal.component_type.data_access": "Data Access Hatch",
+  "component.gtceuterminal.component_type.hpca_component": "HPCA Component",
+  "component.gtceuterminal.component_type.object_holder": "Object Holder",
+  "component.gtceuterminal.component_type.coil": "Heating Coil",
+  "component.gtceuterminal.component_type.casing": "Casing",
+  "component.gtceuterminal.component_type.machine_hatch": "Machine Hatch",
+  "component.gtceuterminal.component_type.dual_hatch": "Dual Hatch",
+  "component.gtceuterminal.component_type.filter": "Filter",
+  "component.gtceuterminal.component_type.unknown": "Unknown Component",
 
   "gui.gtceuterminal.component_upgrade_dialog.info.count_components": "§7Count: §f%s components",
   "gui.gtceuterminal.component_upgrade_dialog.info.current_tier": "§7Current Tier: §f%s",
-
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_upgrade_option": "§l§7Select Upgrade Option:",
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_target_tier": "§l§7Select Target Tier:",
-
   "gui.gtceuterminal.component_upgrade_dialog.actions.confirm_change": "§eConfirm Change",
   "gui.gtceuterminal.component_upgrade_dialog.actions.auto_craft": "§9⚙ Auto-craft",
   "gui.gtceuterminal.component_upgrade_dialog.actions.cancel": "§fCancel",
-
   "gui.gtceuterminal.component_upgrade_dialog.chat.select_upgrade_option_first": "§eSelect an upgrade option first.",
   "gui.gtceuterminal.component_upgrade_dialog.chat.analyzing_me_network": "§7Analyzing ME Network...",
   "gui.gtceuterminal.component_upgrade_dialog.chat.changing_components": "§aChanging %s components...",
-
   "gui.gtceuterminal.component_upgrade_dialog.materials.required_label": "§l§7Required Materials:",
   "gui.gtceuterminal.component_upgrade_dialog.materials.me_materials_verified": "§e⚠ ME materials will be verified on confirmation",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode": "§a§lCREATIVE MODE",
   "gui.gtceuterminal.component_upgrade_dialog.materials.select_option_to_see": "§7Select an option to see materials",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode_not_required": "§a[Creative Mode - Not Required]",
-
   "gui.gtceuterminal.component_upgrade_dialog.option_all_any": "§fALL\n§7(any)",
 
   "gui.gtceuterminal.material_list.quantity.me": "§a%s§7/%s §a[ME]",
   "gui.gtceuterminal.material_list.quantity.inv": "§7%s/%s [Inv]",
   "gui.gtceuterminal.material_list.quantity.mix": "§e%s§7/%s §e[Mix]",
   "gui.gtceuterminal.material_list.quantity.missing": "§c%s§7/%s §c[-%s]",
-
   "gui.gtceuterminal.material_list.tooltip.required": "§7Required: §f%s",
   "gui.gtceuterminal.material_list.tooltip.available_colored": "§7Available: %s",
   "gui.gtceuterminal.material_list.tooltip.sources_header": "§7§l--- Sources ---",
-
   "gui.gtceuterminal.material_list.tooltip.source.inventory_nonzero": "  §7Inventory: §f%s",
   "gui.gtceuterminal.material_list.tooltip.source.inventory_zero": "  §8Inventory: 0",
   "gui.gtceuterminal.material_list.tooltip.source.chests_nonzero": "  §7Chests: §f%s",
   "gui.gtceuterminal.material_list.tooltip.source.chests_zero": "  §8Chests: 0",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_nonzero": "  §e§lME Network: §f%s §8(pending verification)",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_zero": "  §8ME Network: 0",
-
   "gui.gtceuterminal.material_list.tooltip.status.sufficient": "§a✓ Sufficient materials",
   "gui.gtceuterminal.material_list.tooltip.status.missing": "§c✗ Missing %s items",
-
   "gui.gtceuterminal.material_list.tooltip.primary_source.me_pending": "§7Primary source: %s §8(will verify on confirm)",
   "gui.gtceuterminal.material_list.tooltip.primary_source.normal": "§7Primary source: %s",
-
   "gui.gtceuterminal.material_list.source.me_network": "ME Network",
   "gui.gtceuterminal.material_list.source.inventory": "Inventory",
   "gui.gtceuterminal.material_list.source.chests": "Chests",
@@ -405,7 +423,6 @@
   "gui.gtceuterminal.theme_editor.style.gtceu_native": "GTCEu Native",
   "gui.gtceuterminal.theme_editor.style.dark": "Dark",
   "gui.gtceuterminal.theme_editor.style_label": "§7Style: §f%s",
-
   "gui.gtceuterminal.theme_editor.wallpaper": "§7Wallpaper",
   "gui.gtceuterminal.theme_editor.none": "§8None",
   "gui.gtceuterminal.theme_editor.preview": "§7Preview",
@@ -413,15 +430,12 @@
   "gui.gtceuterminal.theme_editor.tab.accent": "Accent",
   "gui.gtceuterminal.theme_editor.tab.bg": "BG",
   "gui.gtceuterminal.theme_editor.tab.panel": "Panel",
-
   "gui.gtceuterminal.theme_editor.options": "§7Options",
   "gui.gtceuterminal.theme_editor.toggle.compact_mode": "Compact mode",
   "gui.gtceuterminal.theme_editor.toggle.show_tooltips": "Show tooltips",
   "gui.gtceuterminal.theme_editor.toggle.show_borders": "Show borders",
-
   "gui.gtceuterminal.theme_editor.button.save": "§aSave",
   "gui.gtceuterminal.theme_editor.button.reset": "§cReset",
-
   "gui.gtceuterminal.theme_editor.preset.default": "Default",
   "gui.gtceuterminal.theme_editor.preset.gtceu_red": "GTCEu Red",
   "gui.gtceuterminal.theme_editor.preset.matrix": "Matrix",

--- a/src/main/resources/assets/gtceuterminal/lang/es_es.json
+++ b/src/main/resources/assets/gtceuterminal/lang/es_es.json
@@ -239,6 +239,8 @@
   "gui.gtceuterminal.energy_analyzer.hatches_label": "Hatches:",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "IN",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "OUT",
+  "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
+  "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s more...",
 
   "gui.gtceuterminal.energy_analyzer.graph_header": "History (EU/s):",

--- a/src/main/resources/assets/gtceuterminal/lang/es_es.json
+++ b/src/main/resources/assets/gtceuterminal/lang/es_es.json
@@ -42,7 +42,6 @@
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_open": "§7Right-click: §bOpen on that machine",
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_air_open": "§7Right-click (air): §bOpen list",
   "item.gtceuterminal.energy_analyzer.tooltip.shift_right_click_manage": "§7Shift + Right-click: §eLink / Unlink machine",
-
   "item.gtceuterminal.energy_analyzer.message.unlinked": "§cUnlinked: §f%s",
   "item.gtceuterminal.energy_analyzer.message.cannot_link_more": "§cCannot link more than §f%d§c machines. Unlink one first.",
   "item.gtceuterminal.energy_analyzer.message.dimension_not_allowed": "§cDimension §f%s§c is not allowed in config.",
@@ -93,7 +92,6 @@
   "item.gtceuterminal.tooltip.me_range.out_of_range": "  §c● Out of Range",
 
   "item.gtceuterminal.multi_structure_manager.behavior.linked_to_me_network": "§a✓ Linked to ME Network",
-
   "item.gtceuterminal.multi_structure_manager.behavior.cooldown_active": "§cCooldown active!",
   "item.gtceuterminal.multi_structure_manager.behavior.multiblock_built": "§aMultiblock built!",
   "item.gtceuterminal.multi_structure_manager.behavior.failed_to_build_check_materials": "§cFailed to build! Check materials.",
@@ -110,6 +108,7 @@
   "item.gtceuterminal.schematic_paster.paste_success.no_skipped": "§aSchematic pasted! §f%d blocks placed",
   "item.gtceuterminal.schematic_paster.paste_success.with_skipped": "§aSchematic pasted! §f%d blocks placed §7(%d skipped)",
   "item.gtceuterminal.schematic_paster.missing_materials": "§cMissing materials: §f%s",
+
   "item.gtceuterminal.power_logger.desc": "Monitors machine power consumption",
 
   "gui.gtceuterminal.planner.title": "§f§lPlacement Planner",
@@ -152,7 +151,6 @@
   "gui.gtceuterminal.blueprint.library.feedback.failed_delete": "§cFailed to delete.",
   "gui.gtceuterminal.blueprint.library.feedback.saved_as": "§aSaved as: %s",
   "gui.gtceuterminal.blueprint.library.feedback.failed_save": "§cFailed to save.",
-
   "gui.gtceuterminal.blueprint.view.title": "Blueprint Viewer",
   "gui.gtceuterminal.blueprint.view.orbit.hints": "§7[Drag] Orbit  [Scroll] Zoom  [Tab] Place Mode  [Esc] Back to Planner",
   "gui.gtceuterminal.blueprint.view.orbit.place_mode": "§9Place Mode",
@@ -174,19 +172,16 @@
   "gui.gtceuterminal.schematic_interface.hint_formed_2": "§8multiblock to copy it",
   "gui.gtceuterminal.schematic_interface.selected": "§7Selected: §f%s",
   "gui.gtceuterminal.schematic_interface.entry.blocks": "§8%s blocks",
-
   "gui.gtceuterminal.schematic_interface.preview.clipboard_content": "§7Clipboard content:",
   "gui.gtceuterminal.schematic_interface.preview.save_to_see": "§8Save it to see preview",
   "gui.gtceuterminal.schematic_interface.preview.no_preview": "§7No preview",
   "gui.gtceuterminal.schematic_interface.preview.info": "§7%s blocks | %sx%sx%s",
   "gui.gtceuterminal.schematic_interface.preview.zoom_hint": "§8Ctrl + Mouse wheel for zoom",
   "gui.gtceuterminal.schematic_interface.preview.rotation_hint": "§8Mouse wheel to rotate preview",
-
   "gui.gtceuterminal.schematic_interface.button.save": "§f§lSave",
   "gui.gtceuterminal.schematic_interface.button.load": "§f§lLoad",
   "gui.gtceuterminal.schematic_interface.button.delete": "§f§lDelete",
   "gui.gtceuterminal.schematic_interface.button.close": "§7Close",
-
   "gui.gtceuterminal.schematic_interface.chat.error.no_clipboard": "§c§lError: §cNo clipboard! Copy a multiblock first.",
   "gui.gtceuterminal.schematic_interface.chat.error.enter_name": "§c§lError: §cPlease enter a name!",
   "gui.gtceuterminal.schematic_interface.chat.error.reserved_name": "§c§lError: §c'Clipboard' is a reserved name!",
@@ -195,7 +190,6 @@
   "gui.gtceuterminal.schematic_interface.chat.error.no_schematic_selected": "§c§lError: §cNo schematic selected!",
   "gui.gtceuterminal.schematic_interface.chat.success.loaded_to_clipboard": "§a§l✓ §aLoaded to clipboard: §f%s",
   "gui.gtceuterminal.schematic_interface.chat.success.deleted": "§c§l✗ §cDeleted: §f%s",
-
   "gui.gtceuterminal.schematic_interface.fallback.multiblock_structure": "Multiblock Structure",
 
   "gui.gtceuterminal.multiblock_manager.nearby_title": "Nearby Multiblocks (%s)",
@@ -231,44 +225,36 @@
   "gui.gtceuterminal.energy_analyzer.out_line": "Out: %s/t  (%s/s)",
   "gui.gtceuterminal.energy_analyzer.net_line": "Net: %s/s",
   "gui.gtceuterminal.energy_analyzer.voltage_line": "Voltage: %s (%sV)  %sA max",
-
   "gui.gtceuterminal.energy_analyzer.recipe_button": "§6Recipe: §7[log ▶]",
   "gui.gtceuterminal.energy_analyzer.recipe_time_left": "%s left",
   "gui.gtceuterminal.energy_analyzer.recipe_finishing": "finishing...",
-
   "gui.gtceuterminal.energy_analyzer.hatches_label": "Hatches:",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "IN",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "OUT",
   "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
   "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s more...",
-
   "gui.gtceuterminal.energy_analyzer.graph_header": "History (EU/s):",
   "gui.gtceuterminal.energy_analyzer.legend_in": "— In",
   "gui.gtceuterminal.energy_analyzer.legend_out": "— Out",
-
   "gui.gtceuterminal.energy_analyzer.machine_options.title": "§6Machine Options",
   "gui.gtceuterminal.energy_analyzer.machine_options.rename": "§e✎  Rename",
   "gui.gtceuterminal.energy_analyzer.machine_options.unlink_machine": "§c✖  Unlink machine",
   "gui.gtceuterminal.energy_analyzer.machine_options.cancel": "§7Cancel",
-
   "gui.gtceuterminal.energy_analyzer.rename_dialog.title": "§6Rename Machine",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.confirm": "§aConfirm",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.cancel": "§7Cancel",
-
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.title": "§cUnlink Machine",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.remove_prompt": "§7Remove §f%s§7?",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.unlink": "§cUnlink",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.cancel": "§7Cancel",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.hint_click_outside_cancel": "§8Click outside to cancel",
-
   "gui.gtceuterminal.energy_analyzer.recipe_log.title": "§6Recipe Log  §7— %s",
   "gui.gtceuterminal.energy_analyzer.recipe_log.output": "§7Output",
   "gui.gtceuterminal.energy_analyzer.recipe_log.time": "§7Time",
   "gui.gtceuterminal.energy_analyzer.recipe_log.when": "§7When",
   "gui.gtceuterminal.energy_analyzer.recipe_log.no_recipes": "§7No recipes recorded yet.",
   "gui.gtceuterminal.energy_analyzer.recipe_log.hint_click_outside_close": "§8Click outside to close",
-
   "gui.gtceuterminal.energy_analyzer.mode.not_formed": "[NOT FORMED]",
   "gui.gtceuterminal.energy_analyzer.mode.consumer": "[Consumer]",
   "gui.gtceuterminal.energy_analyzer.mode.generator": "[Generator]",
@@ -276,59 +262,46 @@
   "gui.gtceuterminal.energy_analyzer.mode.unknown": "[Unknown]",
 
   "gui.gtceuterminal.manager_settings.title": "§lManager Settings",
-
   "gui.gtceuterminal.manager_settings.common.yes": "§aYes",
   "gui.gtceuterminal.manager_settings.common.no": "§cNo",
-
   "gui.gtceuterminal.manager_settings.hatch_mode.label": "§7No Hatch Mode",
   "gui.gtceuterminal.manager_settings.hatch_mode.tooltip": "§7Build without hatches",
   "gui.gtceuterminal.manager_settings.hatch_mode.hint_toggle": "§8← Click to toggle",
-
   "gui.gtceuterminal.manager_settings.tier_mode.label": "§7Tier Mode",
   "gui.gtceuterminal.manager_settings.tier_mode.tooltip": "§7Component tier (1=LV, 2=MV, ...)",
   "gui.gtceuterminal.manager_settings.tier_mode.hint_scroll_type": "§8↑↓ Scroll or type",
-
   "gui.gtceuterminal.manager_settings.repeat_count.label": "§7Repeat Count",
   "gui.gtceuterminal.manager_settings.repeat_count.tooltip": "§7Number of times to repeat the structure",
   "gui.gtceuterminal.manager_settings.repeat_count.hint_layers": "§8Repeatable layers (0-99)",
-
   "gui.gtceuterminal.manager_settings.use_ae2.label": "§7Use AE2",
   "gui.gtceuterminal.manager_settings.use_ae2.tooltip": "§7Wireless Terminal is required",
   "gui.gtceuterminal.manager_settings.use_ae2.hint_use_materials": "§8← Use AE2 for materials",
 
   "gui.gtceuterminal.component_detail.header.title_compact": "§l§f%s",
   "gui.gtceuterminal.component_detail.header.title_full": "§l§f%s - Components",
-
   "gui.gtceuterminal.component_detail.info.multiblock": "§7Multiblock: §f%s",
   "gui.gtceuterminal.component_detail.info.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail.info.distance": "§7Distance: §f%s",
   "gui.gtceuterminal.component_detail.info.components": "§7Components: §f%s §7(§f%s §7groups)",
-
   "gui.gtceuterminal.component_detail.list.header": "§l§7Component Groups:",
-
   "gui.gtceuterminal.component_detail.entry.count": "§7Count: §f%s",
   "gui.gtceuterminal.component_detail.entry.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail.entry.upgrade": "§aUpgrade",
   "gui.gtceuterminal.component_detail.entry.max": "§7Max",
-
   "gui.gtceuterminal.component_detail.actions.bulk_upgrade": "§aBulk Upgrade",
   "gui.gtceuterminal.component_detail.actions.scan": "§7Scan",
   "gui.gtceuterminal.component_detail.actions.back": "§7← Back",
-
   "gui.gtceuterminal.component_detail.notifications.bulk_not_implemented": "§7Bulk upgrade not yet implemented",
   "gui.gtceuterminal.component_detail.notifications.rescanned": "§aRescanned components",
   "gui.gtceuterminal.component_detail.notifications.use_esc_to_close": "§7Use ESC to close",
 
   "gui.gtceuterminal.component_detail_dialog.unknown_multiblock": "Unknown Multiblock",
   "gui.gtceuterminal.component_detail_dialog.header.title": "§l§f%s - Components",
-
   "gui.gtceuterminal.component_detail_dialog.info.multiblock": "§7Multiblock: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.distance": "§7Distance: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.components": "§7Components: §f%s §7(§f%s §7groups)",
-
   "gui.gtceuterminal.component_detail_dialog.list.header": "§l§7Component Groups:",
-
   "gui.gtceuterminal.component_detail_dialog.entry.count": "§7Count: §f%s",
   "gui.gtceuterminal.component_detail_dialog.entry.tier": "§7Tier: §f%s",
 
@@ -345,50 +318,84 @@
 
   "gui.gtceuterminal.component_upgrade_dialog.title": "§l§fUpgrade %s",
 
+  "component.gtceuterminal.component_type.energy_hatch": "Energy Hatch",
+  "component.gtceuterminal.component_type.dynamo_hatch": "Dynamo Hatch",
+  "component.gtceuterminal.component_type.wireless_energy_input": "Wireless Energy Input Hatch",
+  "component.gtceuterminal.component_type.wireless_energy_output": "Wireless Energy Output Hatch",
+  "component.gtceuterminal.component_type.wireless_laser_input": "Wireless Laser Target Hatch",
+  "component.gtceuterminal.component_type.wireless_laser_output": "Wireless Laser Source Hatch",
+  "component.gtceuterminal.component_type.substation_input_energy": "Substation Input Energy",
+  "component.gtceuterminal.component_type.substation_output_energy": "Substation Output Energy",
+  "component.gtceuterminal.component_type.input_bus": "Input Bus",
+  "component.gtceuterminal.component_type.output_bus": "Output Bus",
+  "component.gtceuterminal.component_type.steam_input_bus": "Steam Input Bus",
+  "component.gtceuterminal.component_type.steam_output_bus": "Steam Output Bus",
+  "component.gtceuterminal.component_type.input_hatch": "Input Hatch",
+  "component.gtceuterminal.component_type.output_hatch": "Output Hatch",
+  "component.gtceuterminal.component_type.input_hatch_1x": "Input Hatch (1x)",
+  "component.gtceuterminal.component_type.output_hatch_1x": "Output Hatch (1x)",
+  "component.gtceuterminal.component_type.quad_input_hatch": "Quad Input Hatch (4x)",
+  "component.gtceuterminal.component_type.quad_output_hatch": "Quad Output Hatch (4x)",
+  "component.gtceuterminal.component_type.nonuple_input_hatch": "Nonuple Input Hatch (9x)",
+  "component.gtceuterminal.component_type.nonuple_output_hatch": "Nonuple Output Hatch (9x)",
+  "component.gtceuterminal.component_type.muffler": "Muffler Hatch",
+  "component.gtceuterminal.component_type.maintenance": "Maintenance Hatch",
+  "component.gtceuterminal.component_type.rotor_holder": "Rotor Holder",
+  "component.gtceuterminal.component_type.pump_fluid_hatch": "Pump Fluid Hatch",
+  "component.gtceuterminal.component_type.steam": "Steam Hatch",
+  "component.gtceuterminal.component_type.tank_valve": "Tank Valve",
+  "component.gtceuterminal.component_type.passthrough_hatch": "Passthrough Hatch",
+  "component.gtceuterminal.component_type.parallel_hatch": "Parallel Hatch",
+  "component.gtceuterminal.component_type.input_laser": "Input Laser Hatch",
+  "component.gtceuterminal.component_type.output_laser": "Output Laser Hatch",
+  "component.gtceuterminal.component_type.computation_data_reception": "Computation Data Reception Hatch",
+  "component.gtceuterminal.component_type.computation_data_transmission": "Computation Data Transmission Hatch",
+  "component.gtceuterminal.component_type.optical_data_reception": "Optical Data Reception Hatch",
+  "component.gtceuterminal.component_type.optical_data_transmission": "Optical Data Transmission Hatch",
+  "component.gtceuterminal.component_type.data_access": "Data Access Hatch",
+  "component.gtceuterminal.component_type.hpca_component": "HPCA Component",
+  "component.gtceuterminal.component_type.object_holder": "Object Holder",
+  "component.gtceuterminal.component_type.coil": "Heating Coil",
+  "component.gtceuterminal.component_type.casing": "Casing",
+  "component.gtceuterminal.component_type.machine_hatch": "Machine Hatch",
+  "component.gtceuterminal.component_type.dual_hatch": "Dual Hatch",
+  "component.gtceuterminal.component_type.filter": "Filter",
+  "component.gtceuterminal.component_type.unknown": "Unknown Component",
+
   "gui.gtceuterminal.component_upgrade_dialog.info.count_components": "§7Count: §f%s components",
   "gui.gtceuterminal.component_upgrade_dialog.info.current_tier": "§7Current Tier: §f%s",
-
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_upgrade_option": "§l§7Select Upgrade Option:",
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_target_tier": "§l§7Select Target Tier:",
-
   "gui.gtceuterminal.component_upgrade_dialog.actions.confirm_change": "§eConfirm Change",
   "gui.gtceuterminal.component_upgrade_dialog.actions.auto_craft": "§9⚙ Auto-craft",
   "gui.gtceuterminal.component_upgrade_dialog.actions.cancel": "§fCancel",
-
   "gui.gtceuterminal.component_upgrade_dialog.chat.select_upgrade_option_first": "§eSelect an upgrade option first.",
   "gui.gtceuterminal.component_upgrade_dialog.chat.analyzing_me_network": "§7Analyzing ME Network...",
   "gui.gtceuterminal.component_upgrade_dialog.chat.changing_components": "§aChanging %s components...",
-
   "gui.gtceuterminal.component_upgrade_dialog.materials.required_label": "§l§7Required Materials:",
   "gui.gtceuterminal.component_upgrade_dialog.materials.me_materials_verified": "§e⚠ ME materials will be verified on confirmation",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode": "§a§lCREATIVE MODE",
   "gui.gtceuterminal.component_upgrade_dialog.materials.select_option_to_see": "§7Select an option to see materials",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode_not_required": "§a[Creative Mode - Not Required]",
-
   "gui.gtceuterminal.component_upgrade_dialog.option_all_any": "§fALL\n§7(any)",
 
   "gui.gtceuterminal.material_list.quantity.me": "§a%s§7/%s §a[ME]",
   "gui.gtceuterminal.material_list.quantity.inv": "§7%s/%s [Inv]",
   "gui.gtceuterminal.material_list.quantity.mix": "§e%s§7/%s §e[Mix]",
   "gui.gtceuterminal.material_list.quantity.missing": "§c%s§7/%s §c[-%s]",
-
   "gui.gtceuterminal.material_list.tooltip.required": "§7Required: §f%s",
   "gui.gtceuterminal.material_list.tooltip.available_colored": "§7Available: %s",
   "gui.gtceuterminal.material_list.tooltip.sources_header": "§7§l--- Sources ---",
-
   "gui.gtceuterminal.material_list.tooltip.source.inventory_nonzero": "  §7Inventory: §f%s",
   "gui.gtceuterminal.material_list.tooltip.source.inventory_zero": "  §8Inventory: 0",
   "gui.gtceuterminal.material_list.tooltip.source.chests_nonzero": "  §7Chests: §f%s",
   "gui.gtceuterminal.material_list.tooltip.source.chests_zero": "  §8Chests: 0",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_nonzero": "  §e§lME Network: §f%s §8(pending verification)",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_zero": "  §8ME Network: 0",
-
   "gui.gtceuterminal.material_list.tooltip.status.sufficient": "§a✓ Sufficient materials",
   "gui.gtceuterminal.material_list.tooltip.status.missing": "§c✗ Missing %s items",
-
   "gui.gtceuterminal.material_list.tooltip.primary_source.me_pending": "§7Primary source: %s §8(will verify on confirm)",
   "gui.gtceuterminal.material_list.tooltip.primary_source.normal": "§7Primary source: %s",
-
   "gui.gtceuterminal.material_list.source.me_network": "ME Network",
   "gui.gtceuterminal.material_list.source.inventory": "Inventory",
   "gui.gtceuterminal.material_list.source.chests": "Chests",
@@ -405,7 +412,6 @@
   "gui.gtceuterminal.theme_editor.style.gtceu_native": "GTCEu Native",
   "gui.gtceuterminal.theme_editor.style.dark": "Dark",
   "gui.gtceuterminal.theme_editor.style_label": "§7Style: §f%s",
-
   "gui.gtceuterminal.theme_editor.wallpaper": "§7Wallpaper",
   "gui.gtceuterminal.theme_editor.none": "§8None",
   "gui.gtceuterminal.theme_editor.preview": "§7Preview",
@@ -413,15 +419,12 @@
   "gui.gtceuterminal.theme_editor.tab.accent": "Accent",
   "gui.gtceuterminal.theme_editor.tab.bg": "BG",
   "gui.gtceuterminal.theme_editor.tab.panel": "Panel",
-
   "gui.gtceuterminal.theme_editor.options": "§7Options",
   "gui.gtceuterminal.theme_editor.toggle.compact_mode": "Compact mode",
   "gui.gtceuterminal.theme_editor.toggle.show_tooltips": "Show tooltips",
   "gui.gtceuterminal.theme_editor.toggle.show_borders": "Show borders",
-
   "gui.gtceuterminal.theme_editor.button.save": "§aSave",
   "gui.gtceuterminal.theme_editor.button.reset": "§cReset",
-
   "gui.gtceuterminal.theme_editor.preset.default": "Default",
   "gui.gtceuterminal.theme_editor.preset.gtceu_red": "GTCEu Red",
   "gui.gtceuterminal.theme_editor.preset.matrix": "Matrix",

--- a/src/main/resources/assets/gtceuterminal/lang/ru_ru.json
+++ b/src/main/resources/assets/gtceuterminal/lang/ru_ru.json
@@ -239,6 +239,8 @@
   "gui.gtceuterminal.energy_analyzer.hatches_label": "Hatches:",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "IN",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "OUT",
+  "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
+  "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s more...",
 
   "gui.gtceuterminal.energy_analyzer.graph_header": "History (EU/s):",

--- a/src/main/resources/assets/gtceuterminal/lang/ru_ru.json
+++ b/src/main/resources/assets/gtceuterminal/lang/ru_ru.json
@@ -42,7 +42,6 @@
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_open": "§7Right-click: §bOpen on that machine",
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_air_open": "§7Right-click (air): §bOpen list",
   "item.gtceuterminal.energy_analyzer.tooltip.shift_right_click_manage": "§7Shift + Right-click: §eLink / Unlink machine",
-
   "item.gtceuterminal.energy_analyzer.message.unlinked": "§cUnlinked: §f%s",
   "item.gtceuterminal.energy_analyzer.message.cannot_link_more": "§cCannot link more than §f%d§c machines. Unlink one first.",
   "item.gtceuterminal.energy_analyzer.message.dimension_not_allowed": "§cDimension §f%s§c is not allowed in config.",
@@ -93,7 +92,6 @@
   "item.gtceuterminal.tooltip.me_range.out_of_range": "  §c● Out of Range",
 
   "item.gtceuterminal.multi_structure_manager.behavior.linked_to_me_network": "§a✓ Linked to ME Network",
-
   "item.gtceuterminal.multi_structure_manager.behavior.cooldown_active": "§cCooldown active!",
   "item.gtceuterminal.multi_structure_manager.behavior.multiblock_built": "§aMultiblock built!",
   "item.gtceuterminal.multi_structure_manager.behavior.failed_to_build_check_materials": "§cFailed to build! Check materials.",
@@ -110,6 +108,7 @@
   "item.gtceuterminal.schematic_paster.paste_success.no_skipped": "§aSchematic pasted! §f%d blocks placed",
   "item.gtceuterminal.schematic_paster.paste_success.with_skipped": "§aSchematic pasted! §f%d blocks placed §7(%d skipped)",
   "item.gtceuterminal.schematic_paster.missing_materials": "§cMissing materials: §f%s",
+
   "item.gtceuterminal.power_logger.desc": "Monitors machine power consumption",
 
   "gui.gtceuterminal.planner.title": "§f§lPlacement Planner",
@@ -152,7 +151,6 @@
   "gui.gtceuterminal.blueprint.library.feedback.failed_delete": "§cFailed to delete.",
   "gui.gtceuterminal.blueprint.library.feedback.saved_as": "§aSaved as: %s",
   "gui.gtceuterminal.blueprint.library.feedback.failed_save": "§cFailed to save.",
-
   "gui.gtceuterminal.blueprint.view.title": "Blueprint Viewer",
   "gui.gtceuterminal.blueprint.view.orbit.hints": "§7[Drag] Orbit  [Scroll] Zoom  [Tab] Place Mode  [Esc] Back to Planner",
   "gui.gtceuterminal.blueprint.view.orbit.place_mode": "§9Place Mode",
@@ -174,19 +172,16 @@
   "gui.gtceuterminal.schematic_interface.hint_formed_2": "§8multiblock to copy it",
   "gui.gtceuterminal.schematic_interface.selected": "§7Selected: §f%s",
   "gui.gtceuterminal.schematic_interface.entry.blocks": "§8%s blocks",
-
   "gui.gtceuterminal.schematic_interface.preview.clipboard_content": "§7Clipboard content:",
   "gui.gtceuterminal.schematic_interface.preview.save_to_see": "§8Save it to see preview",
   "gui.gtceuterminal.schematic_interface.preview.no_preview": "§7No preview",
   "gui.gtceuterminal.schematic_interface.preview.info": "§7%s blocks | %sx%sx%s",
   "gui.gtceuterminal.schematic_interface.preview.zoom_hint": "§8Ctrl + Mouse wheel for zoom",
   "gui.gtceuterminal.schematic_interface.preview.rotation_hint": "§8Mouse wheel to rotate preview",
-
   "gui.gtceuterminal.schematic_interface.button.save": "§f§lSave",
   "gui.gtceuterminal.schematic_interface.button.load": "§f§lLoad",
   "gui.gtceuterminal.schematic_interface.button.delete": "§f§lDelete",
   "gui.gtceuterminal.schematic_interface.button.close": "§7Close",
-
   "gui.gtceuterminal.schematic_interface.chat.error.no_clipboard": "§c§lError: §cNo clipboard! Copy a multiblock first.",
   "gui.gtceuterminal.schematic_interface.chat.error.enter_name": "§c§lError: §cPlease enter a name!",
   "gui.gtceuterminal.schematic_interface.chat.error.reserved_name": "§c§lError: §c'Clipboard' is a reserved name!",
@@ -195,7 +190,6 @@
   "gui.gtceuterminal.schematic_interface.chat.error.no_schematic_selected": "§c§lError: §cNo schematic selected!",
   "gui.gtceuterminal.schematic_interface.chat.success.loaded_to_clipboard": "§a§l✓ §aLoaded to clipboard: §f%s",
   "gui.gtceuterminal.schematic_interface.chat.success.deleted": "§c§l✗ §cDeleted: §f%s",
-
   "gui.gtceuterminal.schematic_interface.fallback.multiblock_structure": "Multiblock Structure",
 
   "gui.gtceuterminal.multiblock_manager.nearby_title": "Nearby Multiblocks (%s)",
@@ -231,44 +225,36 @@
   "gui.gtceuterminal.energy_analyzer.out_line": "Out: %s/t  (%s/s)",
   "gui.gtceuterminal.energy_analyzer.net_line": "Net: %s/s",
   "gui.gtceuterminal.energy_analyzer.voltage_line": "Voltage: %s (%sV)  %sA max",
-
   "gui.gtceuterminal.energy_analyzer.recipe_button": "§6Recipe: §7[log ▶]",
   "gui.gtceuterminal.energy_analyzer.recipe_time_left": "%s left",
   "gui.gtceuterminal.energy_analyzer.recipe_finishing": "finishing...",
-
   "gui.gtceuterminal.energy_analyzer.hatches_label": "Hatches:",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "IN",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "OUT",
   "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
   "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s more...",
-
   "gui.gtceuterminal.energy_analyzer.graph_header": "History (EU/s):",
   "gui.gtceuterminal.energy_analyzer.legend_in": "— In",
   "gui.gtceuterminal.energy_analyzer.legend_out": "— Out",
-
   "gui.gtceuterminal.energy_analyzer.machine_options.title": "§6Machine Options",
   "gui.gtceuterminal.energy_analyzer.machine_options.rename": "§e✎  Rename",
   "gui.gtceuterminal.energy_analyzer.machine_options.unlink_machine": "§c✖  Unlink machine",
   "gui.gtceuterminal.energy_analyzer.machine_options.cancel": "§7Cancel",
-
   "gui.gtceuterminal.energy_analyzer.rename_dialog.title": "§6Rename Machine",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.confirm": "§aConfirm",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.cancel": "§7Cancel",
-
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.title": "§cUnlink Machine",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.remove_prompt": "§7Remove §f%s§7?",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.unlink": "§cUnlink",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.cancel": "§7Cancel",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.hint_click_outside_cancel": "§8Click outside to cancel",
-
   "gui.gtceuterminal.energy_analyzer.recipe_log.title": "§6Recipe Log  §7— %s",
   "gui.gtceuterminal.energy_analyzer.recipe_log.output": "§7Output",
   "gui.gtceuterminal.energy_analyzer.recipe_log.time": "§7Time",
   "gui.gtceuterminal.energy_analyzer.recipe_log.when": "§7When",
   "gui.gtceuterminal.energy_analyzer.recipe_log.no_recipes": "§7No recipes recorded yet.",
   "gui.gtceuterminal.energy_analyzer.recipe_log.hint_click_outside_close": "§8Click outside to close",
-
   "gui.gtceuterminal.energy_analyzer.mode.not_formed": "[NOT FORMED]",
   "gui.gtceuterminal.energy_analyzer.mode.consumer": "[Consumer]",
   "gui.gtceuterminal.energy_analyzer.mode.generator": "[Generator]",
@@ -276,59 +262,46 @@
   "gui.gtceuterminal.energy_analyzer.mode.unknown": "[Unknown]",
 
   "gui.gtceuterminal.manager_settings.title": "§lManager Settings",
-
   "gui.gtceuterminal.manager_settings.common.yes": "§aYes",
   "gui.gtceuterminal.manager_settings.common.no": "§cNo",
-
   "gui.gtceuterminal.manager_settings.hatch_mode.label": "§7No Hatch Mode",
   "gui.gtceuterminal.manager_settings.hatch_mode.tooltip": "§7Build without hatches",
   "gui.gtceuterminal.manager_settings.hatch_mode.hint_toggle": "§8← Click to toggle",
-
   "gui.gtceuterminal.manager_settings.tier_mode.label": "§7Tier Mode",
   "gui.gtceuterminal.manager_settings.tier_mode.tooltip": "§7Component tier (1=LV, 2=MV, ...)",
   "gui.gtceuterminal.manager_settings.tier_mode.hint_scroll_type": "§8↑↓ Scroll or type",
-
   "gui.gtceuterminal.manager_settings.repeat_count.label": "§7Repeat Count",
   "gui.gtceuterminal.manager_settings.repeat_count.tooltip": "§7Number of times to repeat the structure",
   "gui.gtceuterminal.manager_settings.repeat_count.hint_layers": "§8Repeatable layers (0-99)",
-
   "gui.gtceuterminal.manager_settings.use_ae2.label": "§7Use AE2",
   "gui.gtceuterminal.manager_settings.use_ae2.tooltip": "§7Wireless Terminal is required",
   "gui.gtceuterminal.manager_settings.use_ae2.hint_use_materials": "§8← Use AE2 for materials",
 
   "gui.gtceuterminal.component_detail.header.title_compact": "§l§f%s",
   "gui.gtceuterminal.component_detail.header.title_full": "§l§f%s - Components",
-
   "gui.gtceuterminal.component_detail.info.multiblock": "§7Multiblock: §f%s",
   "gui.gtceuterminal.component_detail.info.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail.info.distance": "§7Distance: §f%s",
   "gui.gtceuterminal.component_detail.info.components": "§7Components: §f%s §7(§f%s §7groups)",
-
   "gui.gtceuterminal.component_detail.list.header": "§l§7Component Groups:",
-
   "gui.gtceuterminal.component_detail.entry.count": "§7Count: §f%s",
   "gui.gtceuterminal.component_detail.entry.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail.entry.upgrade": "§aUpgrade",
   "gui.gtceuterminal.component_detail.entry.max": "§7Max",
-
   "gui.gtceuterminal.component_detail.actions.bulk_upgrade": "§aBulk Upgrade",
   "gui.gtceuterminal.component_detail.actions.scan": "§7Scan",
   "gui.gtceuterminal.component_detail.actions.back": "§7← Back",
-
   "gui.gtceuterminal.component_detail.notifications.bulk_not_implemented": "§7Bulk upgrade not yet implemented",
   "gui.gtceuterminal.component_detail.notifications.rescanned": "§aRescanned components",
   "gui.gtceuterminal.component_detail.notifications.use_esc_to_close": "§7Use ESC to close",
 
   "gui.gtceuterminal.component_detail_dialog.unknown_multiblock": "Unknown Multiblock",
   "gui.gtceuterminal.component_detail_dialog.header.title": "§l§f%s - Components",
-
   "gui.gtceuterminal.component_detail_dialog.info.multiblock": "§7Multiblock: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.tier": "§7Tier: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.distance": "§7Distance: §f%s",
   "gui.gtceuterminal.component_detail_dialog.info.components": "§7Components: §f%s §7(§f%s §7groups)",
-
   "gui.gtceuterminal.component_detail_dialog.list.header": "§l§7Component Groups:",
-
   "gui.gtceuterminal.component_detail_dialog.entry.count": "§7Count: §f%s",
   "gui.gtceuterminal.component_detail_dialog.entry.tier": "§7Tier: §f%s",
 
@@ -345,50 +318,84 @@
 
   "gui.gtceuterminal.component_upgrade_dialog.title": "§l§fUpgrade %s",
 
+  "component.gtceuterminal.component_type.energy_hatch": "Energy Hatch",
+  "component.gtceuterminal.component_type.dynamo_hatch": "Dynamo Hatch",
+  "component.gtceuterminal.component_type.wireless_energy_input": "Wireless Energy Input Hatch",
+  "component.gtceuterminal.component_type.wireless_energy_output": "Wireless Energy Output Hatch",
+  "component.gtceuterminal.component_type.wireless_laser_input": "Wireless Laser Target Hatch",
+  "component.gtceuterminal.component_type.wireless_laser_output": "Wireless Laser Source Hatch",
+  "component.gtceuterminal.component_type.substation_input_energy": "Substation Input Energy",
+  "component.gtceuterminal.component_type.substation_output_energy": "Substation Output Energy",
+  "component.gtceuterminal.component_type.input_bus": "Input Bus",
+  "component.gtceuterminal.component_type.output_bus": "Output Bus",
+  "component.gtceuterminal.component_type.steam_input_bus": "Steam Input Bus",
+  "component.gtceuterminal.component_type.steam_output_bus": "Steam Output Bus",
+  "component.gtceuterminal.component_type.input_hatch": "Input Hatch",
+  "component.gtceuterminal.component_type.output_hatch": "Output Hatch",
+  "component.gtceuterminal.component_type.input_hatch_1x": "Input Hatch (1x)",
+  "component.gtceuterminal.component_type.output_hatch_1x": "Output Hatch (1x)",
+  "component.gtceuterminal.component_type.quad_input_hatch": "Quad Input Hatch (4x)",
+  "component.gtceuterminal.component_type.quad_output_hatch": "Quad Output Hatch (4x)",
+  "component.gtceuterminal.component_type.nonuple_input_hatch": "Nonuple Input Hatch (9x)",
+  "component.gtceuterminal.component_type.nonuple_output_hatch": "Nonuple Output Hatch (9x)",
+  "component.gtceuterminal.component_type.muffler": "Muffler Hatch",
+  "component.gtceuterminal.component_type.maintenance": "Maintenance Hatch",
+  "component.gtceuterminal.component_type.rotor_holder": "Rotor Holder",
+  "component.gtceuterminal.component_type.pump_fluid_hatch": "Pump Fluid Hatch",
+  "component.gtceuterminal.component_type.steam": "Steam Hatch",
+  "component.gtceuterminal.component_type.tank_valve": "Tank Valve",
+  "component.gtceuterminal.component_type.passthrough_hatch": "Passthrough Hatch",
+  "component.gtceuterminal.component_type.parallel_hatch": "Parallel Hatch",
+  "component.gtceuterminal.component_type.input_laser": "Input Laser Hatch",
+  "component.gtceuterminal.component_type.output_laser": "Output Laser Hatch",
+  "component.gtceuterminal.component_type.computation_data_reception": "Computation Data Reception Hatch",
+  "component.gtceuterminal.component_type.computation_data_transmission": "Computation Data Transmission Hatch",
+  "component.gtceuterminal.component_type.optical_data_reception": "Optical Data Reception Hatch",
+  "component.gtceuterminal.component_type.optical_data_transmission": "Optical Data Transmission Hatch",
+  "component.gtceuterminal.component_type.data_access": "Data Access Hatch",
+  "component.gtceuterminal.component_type.hpca_component": "HPCA Component",
+  "component.gtceuterminal.component_type.object_holder": "Object Holder",
+  "component.gtceuterminal.component_type.coil": "Heating Coil",
+  "component.gtceuterminal.component_type.casing": "Casing",
+  "component.gtceuterminal.component_type.machine_hatch": "Machine Hatch",
+  "component.gtceuterminal.component_type.dual_hatch": "Dual Hatch",
+  "component.gtceuterminal.component_type.filter": "Filter",
+  "component.gtceuterminal.component_type.unknown": "Unknown Component",
+
   "gui.gtceuterminal.component_upgrade_dialog.info.count_components": "§7Count: §f%s components",
   "gui.gtceuterminal.component_upgrade_dialog.info.current_tier": "§7Current Tier: §f%s",
-
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_upgrade_option": "§l§7Select Upgrade Option:",
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_target_tier": "§l§7Select Target Tier:",
-
   "gui.gtceuterminal.component_upgrade_dialog.actions.confirm_change": "§eConfirm Change",
   "gui.gtceuterminal.component_upgrade_dialog.actions.auto_craft": "§9⚙ Auto-craft",
   "gui.gtceuterminal.component_upgrade_dialog.actions.cancel": "§fCancel",
-
   "gui.gtceuterminal.component_upgrade_dialog.chat.select_upgrade_option_first": "§eSelect an upgrade option first.",
   "gui.gtceuterminal.component_upgrade_dialog.chat.analyzing_me_network": "§7Analyzing ME Network...",
   "gui.gtceuterminal.component_upgrade_dialog.chat.changing_components": "§aChanging %s components...",
-
   "gui.gtceuterminal.component_upgrade_dialog.materials.required_label": "§l§7Required Materials:",
   "gui.gtceuterminal.component_upgrade_dialog.materials.me_materials_verified": "§e⚠ ME materials will be verified on confirmation",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode": "§a§lCREATIVE MODE",
   "gui.gtceuterminal.component_upgrade_dialog.materials.select_option_to_see": "§7Select an option to see materials",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode_not_required": "§a[Creative Mode - Not Required]",
-
   "gui.gtceuterminal.component_upgrade_dialog.option_all_any": "§fALL\n§7(any)",
 
   "gui.gtceuterminal.material_list.quantity.me": "§a%s§7/%s §a[ME]",
   "gui.gtceuterminal.material_list.quantity.inv": "§7%s/%s [Inv]",
   "gui.gtceuterminal.material_list.quantity.mix": "§e%s§7/%s §e[Mix]",
   "gui.gtceuterminal.material_list.quantity.missing": "§c%s§7/%s §c[-%s]",
-
   "gui.gtceuterminal.material_list.tooltip.required": "§7Required: §f%s",
   "gui.gtceuterminal.material_list.tooltip.available_colored": "§7Available: %s",
   "gui.gtceuterminal.material_list.tooltip.sources_header": "§7§l--- Sources ---",
-
   "gui.gtceuterminal.material_list.tooltip.source.inventory_nonzero": "  §7Inventory: §f%s",
   "gui.gtceuterminal.material_list.tooltip.source.inventory_zero": "  §8Inventory: 0",
   "gui.gtceuterminal.material_list.tooltip.source.chests_nonzero": "  §7Chests: §f%s",
   "gui.gtceuterminal.material_list.tooltip.source.chests_zero": "  §8Chests: 0",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_nonzero": "  §e§lME Network: §f%s §8(pending verification)",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_zero": "  §8ME Network: 0",
-
   "gui.gtceuterminal.material_list.tooltip.status.sufficient": "§a✓ Sufficient materials",
   "gui.gtceuterminal.material_list.tooltip.status.missing": "§c✗ Missing %s items",
-
   "gui.gtceuterminal.material_list.tooltip.primary_source.me_pending": "§7Primary source: %s §8(will verify on confirm)",
   "gui.gtceuterminal.material_list.tooltip.primary_source.normal": "§7Primary source: %s",
-
   "gui.gtceuterminal.material_list.source.me_network": "ME Network",
   "gui.gtceuterminal.material_list.source.inventory": "Inventory",
   "gui.gtceuterminal.material_list.source.chests": "Chests",
@@ -405,7 +412,6 @@
   "gui.gtceuterminal.theme_editor.style.gtceu_native": "GTCEu Native",
   "gui.gtceuterminal.theme_editor.style.dark": "Dark",
   "gui.gtceuterminal.theme_editor.style_label": "§7Style: §f%s",
-
   "gui.gtceuterminal.theme_editor.wallpaper": "§7Wallpaper",
   "gui.gtceuterminal.theme_editor.none": "§8None",
   "gui.gtceuterminal.theme_editor.preview": "§7Preview",
@@ -413,15 +419,12 @@
   "gui.gtceuterminal.theme_editor.tab.accent": "Accent",
   "gui.gtceuterminal.theme_editor.tab.bg": "BG",
   "gui.gtceuterminal.theme_editor.tab.panel": "Panel",
-
   "gui.gtceuterminal.theme_editor.options": "§7Options",
   "gui.gtceuterminal.theme_editor.toggle.compact_mode": "Compact mode",
   "gui.gtceuterminal.theme_editor.toggle.show_tooltips": "Show tooltips",
   "gui.gtceuterminal.theme_editor.toggle.show_borders": "Show borders",
-
   "gui.gtceuterminal.theme_editor.button.save": "§aSave",
   "gui.gtceuterminal.theme_editor.button.reset": "§cReset",
-
   "gui.gtceuterminal.theme_editor.preset.default": "Default",
   "gui.gtceuterminal.theme_editor.preset.gtceu_red": "GTCEu Red",
   "gui.gtceuterminal.theme_editor.preset.matrix": "Matrix",

--- a/src/main/resources/assets/gtceuterminal/lang/zh_cn.json
+++ b/src/main/resources/assets/gtceuterminal/lang/zh_cn.json
@@ -239,6 +239,8 @@
   "gui.gtceuterminal.energy_analyzer.hatches_label": "仓：",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "输入",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "输出",
+  "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
+  "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s 个更多...",
 
   "gui.gtceuterminal.energy_analyzer.graph_header": "历史记录（EU/s）：",

--- a/src/main/resources/assets/gtceuterminal/lang/zh_cn.json
+++ b/src/main/resources/assets/gtceuterminal/lang/zh_cn.json
@@ -42,7 +42,6 @@
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_open": "§7右键：§b在该机器上打开",
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_air_open": "§7右键（空位）：§b打开列表",
   "item.gtceuterminal.energy_analyzer.tooltip.shift_right_click_manage": "§7Shift + 右键：§e链接 / 取消链接机器",
-
   "item.gtceuterminal.energy_analyzer.message.unlinked": "§c已取消连接：§f%s",
   "item.gtceuterminal.energy_analyzer.message.cannot_link_more": "§c无法连接超过 §f%d§c 台机器。请先取消一个连接。",
   "item.gtceuterminal.energy_analyzer.message.dimension_not_allowed": "§c配置中不允许维度 §f%s§c。",
@@ -93,7 +92,6 @@
   "item.gtceuterminal.tooltip.me_range.out_of_range": "  §c● 超出范围",
 
   "item.gtceuterminal.multi_structure_manager.behavior.linked_to_me_network": "§a✓ 已连接到ME网络",
-
   "item.gtceuterminal.multi_structure_manager.behavior.cooldown_active": "§c冷却中！",
   "item.gtceuterminal.multi_structure_manager.behavior.multiblock_built": "§a多方块已建造！",
   "item.gtceuterminal.multi_structure_manager.behavior.failed_to_build_check_materials": "§c建造失败！请检查材料。",
@@ -110,6 +108,7 @@
   "item.gtceuterminal.schematic_paster.paste_success.no_skipped": "§a结构已粘贴！§f%d 个方块已放置",
   "item.gtceuterminal.schematic_paster.paste_success.with_skipped": "§a结构已粘贴！§f%d 个方块已放置 §7(%d 个已跳过)",
   "item.gtceuterminal.schematic_paster.missing_materials": "§c缺少材料：§f%s",
+
   "item.gtceuterminal.power_logger.desc": "监控机器电力消耗",
 
   "gui.gtceuterminal.planner.title": "§f§l放置规划器",
@@ -152,7 +151,6 @@
   "gui.gtceuterminal.blueprint.library.feedback.failed_delete": "§c删除失败。",
   "gui.gtceuterminal.blueprint.library.feedback.saved_as": "§a已保存为： %s",
   "gui.gtceuterminal.blueprint.library.feedback.failed_save": "§c保存失败。",
-
   "gui.gtceuterminal.blueprint.view.title": "蓝图库查看器",
   "gui.gtceuterminal.blueprint.view.orbit.hints": "§7[拖拽] 旋转  [滚轮] 缩放  [Tab] 放置模式  [Esc] 返回规划器",
   "gui.gtceuterminal.blueprint.view.orbit.place_mode": "§9放置模式",
@@ -174,19 +172,16 @@
   "gui.gtceuterminal.schematic_interface.hint_formed_2": "§8多方块以复制它",
   "gui.gtceuterminal.schematic_interface.selected": "§7已选择：§f%s",
   "gui.gtceuterminal.schematic_interface.entry.blocks": "§8%s 块",
-
   "gui.gtceuterminal.schematic_interface.preview.clipboard_content": "§7剪贴板内容：",
   "gui.gtceuterminal.schematic_interface.preview.save_to_see": "§8保存后可查看预览",
   "gui.gtceuterminal.schematic_interface.preview.no_preview": "§7暂无预览",
   "gui.gtceuterminal.schematic_interface.preview.info": "§7%s 块 | %sx%sx%s",
   "gui.gtceuterminal.schematic_interface.preview.zoom_hint": "§8Ctrl + 鼠标滚轮用于缩放",
   "gui.gtceuterminal.schematic_interface.preview.rotation_hint": "§8使用鼠标滚轮旋转预览",
-
   "gui.gtceuterminal.schematic_interface.button.save": "§f§l保存",
   "gui.gtceuterminal.schematic_interface.button.load": "§f§l加载",
   "gui.gtceuterminal.schematic_interface.button.delete": "§f§l删除",
   "gui.gtceuterminal.schematic_interface.button.close": "§7关闭",
-
   "gui.gtceuterminal.schematic_interface.chat.error.no_clipboard": "§c§l错误：§c没有剪贴板！请先复制一个多方块。",
   "gui.gtceuterminal.schematic_interface.chat.error.enter_name": "§c§l错误：§c请输入名称！",
   "gui.gtceuterminal.schematic_interface.chat.error.reserved_name": "§c§l错误：§c'Clipboard' 是保留名称！",
@@ -195,7 +190,6 @@
   "gui.gtceuterminal.schematic_interface.chat.error.no_schematic_selected": "§c§l错误：§c未选择结构！",
   "gui.gtceuterminal.schematic_interface.chat.success.loaded_to_clipboard": "§a§l✓ §a已加载到剪贴板：§f%s",
   "gui.gtceuterminal.schematic_interface.chat.success.deleted": "§c§l✗ §c已删除：§f%s",
-
   "gui.gtceuterminal.schematic_interface.fallback.multiblock_structure": "多方块结构",
 
   "gui.gtceuterminal.multiblock_manager.nearby_title": "附近的多方块（%s）",
@@ -231,44 +225,36 @@
   "gui.gtceuterminal.energy_analyzer.out_line": "输出：%s/t（%s/s）",
   "gui.gtceuterminal.energy_analyzer.net_line": "净增：%s/s",
   "gui.gtceuterminal.energy_analyzer.voltage_line": "电压：%s（%sV）  %sA 最大",
-
   "gui.gtceuterminal.energy_analyzer.recipe_button": "§6配方：§7[日志 ▶]",
   "gui.gtceuterminal.energy_analyzer.recipe_time_left": "%s 后完成",
   "gui.gtceuterminal.energy_analyzer.recipe_finishing": "即将完成...",
-
   "gui.gtceuterminal.energy_analyzer.hatches_label": "仓：",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "输入",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "输出",
   "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
   "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s 个更多...",
-
   "gui.gtceuterminal.energy_analyzer.graph_header": "历史记录（EU/s）：",
   "gui.gtceuterminal.energy_analyzer.legend_in": "— 输入",
   "gui.gtceuterminal.energy_analyzer.legend_out": "— 输出",
-
   "gui.gtceuterminal.energy_analyzer.machine_options.title": "§6机器选项",
   "gui.gtceuterminal.energy_analyzer.machine_options.rename": "§e✎  重命名",
   "gui.gtceuterminal.energy_analyzer.machine_options.unlink_machine": "§c✖  解除连接机器",
   "gui.gtceuterminal.energy_analyzer.machine_options.cancel": "§7取消",
-
   "gui.gtceuterminal.energy_analyzer.rename_dialog.title": "§6重命名机器",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.confirm": "§a确认",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.cancel": "§7取消",
-
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.title": "§c解除连接机器",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.remove_prompt": "§7移除 §f%s§7？",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.unlink": "§c解除连接",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.cancel": "§7取消",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.hint_click_outside_cancel": "§8点击空白处取消",
-
   "gui.gtceuterminal.energy_analyzer.recipe_log.title": "§6配方日志  §7— %s",
   "gui.gtceuterminal.energy_analyzer.recipe_log.output": "§7输出",
   "gui.gtceuterminal.energy_analyzer.recipe_log.time": "§7时间",
   "gui.gtceuterminal.energy_analyzer.recipe_log.when": "§7时间点",
   "gui.gtceuterminal.energy_analyzer.recipe_log.no_recipes": "§7尚无记录的配方。",
   "gui.gtceuterminal.energy_analyzer.recipe_log.hint_click_outside_close": "§8点击空白处关闭",
-
   "gui.gtceuterminal.energy_analyzer.mode.not_formed": "[未成型]",
   "gui.gtceuterminal.energy_analyzer.mode.consumer": "[消费者]",
   "gui.gtceuterminal.energy_analyzer.mode.generator": "[发电机]",
@@ -276,59 +262,46 @@
   "gui.gtceuterminal.energy_analyzer.mode.unknown": "[未知]",
 
   "gui.gtceuterminal.manager_settings.title": "§l管理设置",
-
   "gui.gtceuterminal.manager_settings.common.yes": "§a是",
   "gui.gtceuterminal.manager_settings.common.no": "§c否",
-
   "gui.gtceuterminal.manager_settings.hatch_mode.label": "§7无仓模式",
   "gui.gtceuterminal.manager_settings.hatch_mode.tooltip": "§7在不使用能源仓/动力仓的情况下建造",
   "gui.gtceuterminal.manager_settings.hatch_mode.hint_toggle": "§8← 点击切换",
-
   "gui.gtceuterminal.manager_settings.tier_mode.label": "§7等级模式",
   "gui.gtceuterminal.manager_settings.tier_mode.tooltip": "§7组件等级（1=LV，2=MV，...）",
   "gui.gtceuterminal.manager_settings.tier_mode.hint_scroll_type": "§8↑↓ 滚动或输入",
-
   "gui.gtceuterminal.manager_settings.repeat_count.label": "§7重复次数",
   "gui.gtceuterminal.manager_settings.repeat_count.tooltip": "§7结构重复的次数",
   "gui.gtceuterminal.manager_settings.repeat_count.hint_layers": "§8可重复层数（0-99）",
-
   "gui.gtceuterminal.manager_settings.use_ae2.label": "§7使用 AE2",
   "gui.gtceuterminal.manager_settings.use_ae2.tooltip": "§7需要无线终端",
   "gui.gtceuterminal.manager_settings.use_ae2.hint_use_materials": "§8← 使用 AE2 作为材料",
 
   "gui.gtceuterminal.component_detail.header.title_compact": "§l§f%s",
   "gui.gtceuterminal.component_detail.header.title_full": "§l§f%s - 组件",
-
   "gui.gtceuterminal.component_detail.info.multiblock": "§7多方块：§f%s",
   "gui.gtceuterminal.component_detail.info.tier": "§7等级：§f%s",
   "gui.gtceuterminal.component_detail.info.distance": "§7距离：§f%s",
   "gui.gtceuterminal.component_detail.info.components": "§7组件：§f%s §7(§f%s §7组)",
-
   "gui.gtceuterminal.component_detail.list.header": "§l§7组件组：",
-
   "gui.gtceuterminal.component_detail.entry.count": "§7数量：§f%s",
   "gui.gtceuterminal.component_detail.entry.tier": "§7等级：§f%s",
   "gui.gtceuterminal.component_detail.entry.upgrade": "§a升级",
   "gui.gtceuterminal.component_detail.entry.max": "§7最大",
-
   "gui.gtceuterminal.component_detail.actions.bulk_upgrade": "§a批量升级",
   "gui.gtceuterminal.component_detail.actions.scan": "§7扫描",
   "gui.gtceuterminal.component_detail.actions.back": "§7← 返回",
-
   "gui.gtceuterminal.component_detail.notifications.bulk_not_implemented": "§7批量升级尚未实现",
   "gui.gtceuterminal.component_detail.notifications.rescanned": "§a已重新扫描组件",
   "gui.gtceuterminal.component_detail.notifications.use_esc_to_close": "§7使用 ESC 关闭",
 
   "gui.gtceuterminal.component_detail_dialog.unknown_multiblock": "未知多方块",
   "gui.gtceuterminal.component_detail_dialog.header.title": "§l§f%s - 组件",
-
   "gui.gtceuterminal.component_detail_dialog.info.multiblock": "§7多方块：§f%s",
   "gui.gtceuterminal.component_detail_dialog.info.tier": "§7等级：§f%s",
   "gui.gtceuterminal.component_detail_dialog.info.distance": "§7距离：§f%s",
-  "gui.gtceuterminal.component_detail_dialog.info.components": "§7组件：§f%s §7(§f%s §7组)",
-
-  "gui.gtceuterminal.component_detail_dialog.list.header": "§l§7组件组：",
-
+  "gui.gtceuterminal.component_detail_dialog.info.components": "§7组件：§f%s §7(§f%s §7类)",
+  "gui.gtceuterminal.component_detail_dialog.list.header": "§l§7组件类型：",
   "gui.gtceuterminal.component_detail_dialog.entry.count": "§7数量：§f%s",
   "gui.gtceuterminal.component_detail_dialog.entry.tier": "§7等级：§f%s",
 
@@ -336,6 +309,7 @@
   "gui.gtceuterminal.group_upgrade_dialog.upgrade_x": "§e升级 %sx %s",
   "gui.gtceuterminal.group_upgrade_dialog.from": "§7来自：§f%s",
   "gui.gtceuterminal.group_upgrade_dialog.to": "§7到：§f%s",
+  "gui.gtceuterminal.group_upgrade_dialog.type_with_tier": "%s（%s）",
   "gui.gtceuterminal.group_upgrade_dialog.creative_no_materials": "§a创造模式 - 无需材料",
   "gui.gtceuterminal.group_upgrade_dialog.required_materials": "§7所需材料：",
   "gui.gtceuterminal.group_upgrade_dialog.confirm_upgrade_all": "升级全部（%s）",
@@ -343,52 +317,96 @@
   "gui.gtceuterminal.group_upgrade_dialog.cancel": "取消",
   "gui.gtceuterminal.group_upgrade_dialog.unknown_coil": "未知线圈",
 
+  "gui.gtceuterminal.coil_tier.cupronickel": "白铜",
+  "gui.gtceuterminal.coil_tier.kanthal": "坎塔尔",
+  "gui.gtceuterminal.coil_tier.nichrome": "镍铬",
+  "gui.gtceuterminal.coil_tier.rtm_alloy": "钌钨钼合金",
+  "gui.gtceuterminal.coil_tier.hss_g": "高速钢-G",
+  "gui.gtceuterminal.coil_tier.naquadah": "硅岩",
+  "gui.gtceuterminal.coil_tier.trinium": "凯金",
+  "gui.gtceuterminal.coil_tier.tritanium": "三钛",
+  "gui.gtceuterminal.coil_tier.unknown": "未知线圈",
+
   "gui.gtceuterminal.component_upgrade_dialog.title": "§l§f升级 %s",
+
+  "component.gtceuterminal.component_type.energy_hatch": "能源仓",
+  "component.gtceuterminal.component_type.dynamo_hatch": "动力仓",
+  "component.gtceuterminal.component_type.wireless_energy_input": "无线能源输入仓",
+  "component.gtceuterminal.component_type.wireless_energy_output": "无线能源输出仓",
+  "component.gtceuterminal.component_type.wireless_laser_input": "无线激光靶仓",
+  "component.gtceuterminal.component_type.wireless_laser_output": "无线激光源仓",
+  "component.gtceuterminal.component_type.substation_input_energy": "变电站能源输入",
+  "component.gtceuterminal.component_type.substation_output_energy": "变电站能源输出",
+  "component.gtceuterminal.component_type.input_bus": "输入总线",
+  "component.gtceuterminal.component_type.output_bus": "输出总线",
+  "component.gtceuterminal.component_type.steam_input_bus": "蒸汽输入总线",
+  "component.gtceuterminal.component_type.steam_output_bus": "蒸汽输出总线",
+  "component.gtceuterminal.component_type.input_hatch": "输入仓",
+  "component.gtceuterminal.component_type.output_hatch": "输出仓",
+  "component.gtceuterminal.component_type.input_hatch_1x": "输入仓",
+  "component.gtceuterminal.component_type.output_hatch_1x": "输出仓",
+  "component.gtceuterminal.component_type.quad_input_hatch": "四重输入仓",
+  "component.gtceuterminal.component_type.quad_output_hatch": "四重输出仓",
+  "component.gtceuterminal.component_type.nonuple_input_hatch": "九重输入仓",
+  "component.gtceuterminal.component_type.nonuple_output_hatch": "九重输出仓",
+  "component.gtceuterminal.component_type.muffler": "消声仓",
+  "component.gtceuterminal.component_type.maintenance": "维护仓",
+  "component.gtceuterminal.component_type.rotor_holder": "转子支架",
+  "component.gtceuterminal.component_type.pump_fluid_hatch": "泵液仓",
+  "component.gtceuterminal.component_type.steam": "蒸汽仓",
+  "component.gtceuterminal.component_type.tank_valve": "储罐阀门",
+  "component.gtceuterminal.component_type.passthrough_hatch": "直通仓",
+  "component.gtceuterminal.component_type.parallel_hatch": "并行仓",
+  "component.gtceuterminal.component_type.input_laser": "激光输入仓",
+  "component.gtceuterminal.component_type.output_laser": "激光输出仓",
+  "component.gtceuterminal.component_type.computation_data_reception": "计算数据接收仓",
+  "component.gtceuterminal.component_type.computation_data_transmission": "计算数据发送仓",
+  "component.gtceuterminal.component_type.optical_data_reception": "光学数据接收仓",
+  "component.gtceuterminal.component_type.optical_data_transmission": "光学数据发送仓",
+  "component.gtceuterminal.component_type.data_access": "数据访问仓",
+  "component.gtceuterminal.component_type.hpca_component": "HPCA 组件",
+  "component.gtceuterminal.component_type.object_holder": "对象支架",
+  "component.gtceuterminal.component_type.coil": "加热线圈",
+  "component.gtceuterminal.component_type.casing": "外壳",
+  "component.gtceuterminal.component_type.machine_hatch": "机器仓",
+  "component.gtceuterminal.component_type.dual_hatch": "双联仓",
+  "component.gtceuterminal.component_type.filter": "过滤器",
+  "component.gtceuterminal.component_type.unknown": "未知组件",
 
   "gui.gtceuterminal.component_upgrade_dialog.info.count_components": "§7数量：§f%s 个组件",
   "gui.gtceuterminal.component_upgrade_dialog.info.current_tier": "§7当前等级：§f%s",
-
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_upgrade_option": "§l§7选择升级选项：",
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_target_tier": "§l§7选择目标等级：",
-
   "gui.gtceuterminal.component_upgrade_dialog.actions.confirm_change": "§e确认更改",
   "gui.gtceuterminal.component_upgrade_dialog.actions.auto_craft": "§9⚙ 自动加工",
   "gui.gtceuterminal.component_upgrade_dialog.actions.cancel": "§f取消",
-
   "gui.gtceuterminal.component_upgrade_dialog.chat.select_upgrade_option_first": "§e请先选择升级选项。",
   "gui.gtceuterminal.component_upgrade_dialog.chat.analyzing_me_network": "§7正在分析ME网络...",
   "gui.gtceuterminal.component_upgrade_dialog.chat.changing_components": "§a正在更改%s个组件...",
-
   "gui.gtceuterminal.component_upgrade_dialog.materials.required_label": "§l§7所需材料：",
   "gui.gtceuterminal.component_upgrade_dialog.materials.me_materials_verified": "§e⚠ 将在确认时验证ME材料",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode": "§a§l创造模式",
   "gui.gtceuterminal.component_upgrade_dialog.materials.select_option_to_see": "§7选择一个选项以查看材料",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode_not_required": "§a[创造模式 - 不需要]",
-
   "gui.gtceuterminal.component_upgrade_dialog.option_all_any": "§f全部\n§7(任意)",
 
   "gui.gtceuterminal.material_list.quantity.me": "§a%s§7/%s §a[ME]",
   "gui.gtceuterminal.material_list.quantity.inv": "§7%s/%s [背包]",
   "gui.gtceuterminal.material_list.quantity.mix": "§e%s§7/%s §e[混合]",
   "gui.gtceuterminal.material_list.quantity.missing": "§c%s§7/%s §c[-%s]",
-
   "gui.gtceuterminal.material_list.tooltip.required": "§7需求：§f%s",
   "gui.gtceuterminal.material_list.tooltip.available_colored": "§7可用：%s",
   "gui.gtceuterminal.material_list.tooltip.sources_header": "§7§l--- 资源来源 ---",
-
   "gui.gtceuterminal.material_list.tooltip.source.inventory_nonzero": "  §7背包：§f%s",
   "gui.gtceuterminal.material_list.tooltip.source.inventory_zero": "  §8背包：0",
   "gui.gtceuterminal.material_list.tooltip.source.chests_nonzero": "  §7箱子：§f%s",
   "gui.gtceuterminal.material_list.tooltip.source.chests_zero": "  §8箱子：0",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_nonzero": "  §e§lME网络：§f%s §8(确认时验证)",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_zero": "  §8ME网络：0",
-
   "gui.gtceuterminal.material_list.tooltip.status.sufficient": "§a✓ 材料充足",
   "gui.gtceuterminal.material_list.tooltip.status.missing": "§c✗ 缺少 %s 个物品",
-
   "gui.gtceuterminal.material_list.tooltip.primary_source.me_pending": "§7主要来源：%s §8(确认时验证)",
   "gui.gtceuterminal.material_list.tooltip.primary_source.normal": "§7主要来源：%s",
-
   "gui.gtceuterminal.material_list.source.me_network": "ME网络",
   "gui.gtceuterminal.material_list.source.inventory": "背包",
   "gui.gtceuterminal.material_list.source.chests": "箱子",
@@ -405,7 +423,6 @@
   "gui.gtceuterminal.theme_editor.style.gtceu_native": "GTCEu 原生",
   "gui.gtceuterminal.theme_editor.style.dark": "深色",
   "gui.gtceuterminal.theme_editor.style_label": "§7风格：§f%s",
-
   "gui.gtceuterminal.theme_editor.wallpaper": "§7壁纸",
   "gui.gtceuterminal.theme_editor.none": "§8无",
   "gui.gtceuterminal.theme_editor.preview": "§7预览",
@@ -413,15 +430,12 @@
   "gui.gtceuterminal.theme_editor.tab.accent": "强调色",
   "gui.gtceuterminal.theme_editor.tab.bg": "背景",
   "gui.gtceuterminal.theme_editor.tab.panel": "面板",
-
   "gui.gtceuterminal.theme_editor.options": "§7选项",
   "gui.gtceuterminal.theme_editor.toggle.compact_mode": "紧凑模式",
   "gui.gtceuterminal.theme_editor.toggle.show_tooltips": "显示提示",
   "gui.gtceuterminal.theme_editor.toggle.show_borders": "显示边框",
-
   "gui.gtceuterminal.theme_editor.button.save": "§a保存",
   "gui.gtceuterminal.theme_editor.button.reset": "§c重置",
-
   "gui.gtceuterminal.theme_editor.preset.default": "默认",
   "gui.gtceuterminal.theme_editor.preset.gtceu_red": "GTCEu 红色",
   "gui.gtceuterminal.theme_editor.preset.matrix": "矩阵",

--- a/src/main/resources/assets/gtceuterminal/lang/zh_cn.json
+++ b/src/main/resources/assets/gtceuterminal/lang/zh_cn.json
@@ -318,8 +318,8 @@
   "gui.gtceuterminal.group_upgrade_dialog.unknown_coil": "未知线圈",
 
   "gui.gtceuterminal.coil_tier.cupronickel": "白铜",
-  "gui.gtceuterminal.coil_tier.kanthal": "坎塔尔",
-  "gui.gtceuterminal.coil_tier.nichrome": "镍铬",
+  "gui.gtceuterminal.coil_tier.kanthal": "坎塔尔合金",
+  "gui.gtceuterminal.coil_tier.nichrome": "镍铬合金",
   "gui.gtceuterminal.coil_tier.rtm_alloy": "钌钨钼合金",
   "gui.gtceuterminal.coil_tier.hss_g": "高速钢-G",
   "gui.gtceuterminal.coil_tier.naquadah": "硅岩",

--- a/src/main/resources/assets/gtceuterminal/lang/zh_tw.json
+++ b/src/main/resources/assets/gtceuterminal/lang/zh_tw.json
@@ -239,6 +239,8 @@
   "gui.gtceuterminal.energy_analyzer.hatches_label": "倉：",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "輸入",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "輸出",
+  "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
+  "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s 個更多...",
 
   "gui.gtceuterminal.energy_analyzer.graph_header": "歷史記錄（EU/s）：",

--- a/src/main/resources/assets/gtceuterminal/lang/zh_tw.json
+++ b/src/main/resources/assets/gtceuterminal/lang/zh_tw.json
@@ -42,7 +42,6 @@
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_open": "§7右鍵：§b在該機器上開啟",
   "item.gtceuterminal.energy_analyzer.tooltip.right_click_air_open": "§7右鍵（空位）：§b開啟列表",
   "item.gtceuterminal.energy_analyzer.tooltip.shift_right_click_manage": "§7Shift + 右鍵：§e連結 / 取消連結機器",
-
   "item.gtceuterminal.energy_analyzer.message.unlinked": "§c已取消連線：§f%s",
   "item.gtceuterminal.energy_analyzer.message.cannot_link_more": "§c無法連線超過 §f%d§c 臺機器。請先取消一個連線。",
   "item.gtceuterminal.energy_analyzer.message.dimension_not_allowed": "§c配置中不允許維度 §f%s§c。",
@@ -93,7 +92,6 @@
   "item.gtceuterminal.tooltip.me_range.out_of_range": "  §c● 超出範圍",
 
   "item.gtceuterminal.multi_structure_manager.behavior.linked_to_me_network": "§a✓ 已連線到ME網路",
-
   "item.gtceuterminal.multi_structure_manager.behavior.cooldown_active": "§c冷卻中！",
   "item.gtceuterminal.multi_structure_manager.behavior.multiblock_built": "§a多方塊已建造！",
   "item.gtceuterminal.multi_structure_manager.behavior.failed_to_build_check_materials": "§c建造失敗！請檢查材料。",
@@ -110,6 +108,7 @@
   "item.gtceuterminal.schematic_paster.paste_success.no_skipped": "§a結構已貼上！§f%d 個方塊已放置",
   "item.gtceuterminal.schematic_paster.paste_success.with_skipped": "§a結構已貼上！§f%d 個方塊已放置 §7(%d 個已跳過)",
   "item.gtceuterminal.schematic_paster.missing_materials": "§c缺少材料：§f%s",
+
   "item.gtceuterminal.power_logger.desc": "監控機器電力消耗",
 
   "gui.gtceuterminal.planner.title": "§f§l放置規劃器",
@@ -152,7 +151,6 @@
   "gui.gtceuterminal.blueprint.library.feedback.failed_delete": "§c刪除失敗。",
   "gui.gtceuterminal.blueprint.library.feedback.saved_as": "§a已儲存為： %s",
   "gui.gtceuterminal.blueprint.library.feedback.failed_save": "§c儲存失敗。",
-
   "gui.gtceuterminal.blueprint.view.title": "藍相簿檢視器",
   "gui.gtceuterminal.blueprint.view.orbit.hints": "§7[拖拽] 旋轉  [滾輪] 縮放  [Tab] 放置模式  [Esc] 返回規劃器",
   "gui.gtceuterminal.blueprint.view.orbit.place_mode": "§9放置模式",
@@ -174,19 +172,16 @@
   "gui.gtceuterminal.schematic_interface.hint_formed_2": "§8多方塊以複製它",
   "gui.gtceuterminal.schematic_interface.selected": "§7已選擇：§f%s",
   "gui.gtceuterminal.schematic_interface.entry.blocks": "§8%s 塊",
-
   "gui.gtceuterminal.schematic_interface.preview.clipboard_content": "§7剪貼簿內容：",
   "gui.gtceuterminal.schematic_interface.preview.save_to_see": "§8儲存後可檢視預覽",
   "gui.gtceuterminal.schematic_interface.preview.no_preview": "§7暫無預覽",
   "gui.gtceuterminal.schematic_interface.preview.info": "§7%s 塊 | %sx%sx%s",
   "gui.gtceuterminal.schematic_interface.preview.zoom_hint": "§8Ctrl + 滑鼠滾輪用於縮放",
   "gui.gtceuterminal.schematic_interface.preview.rotation_hint": "§8使用滑鼠滾輪旋轉預覽",
-
   "gui.gtceuterminal.schematic_interface.button.save": "§f§l儲存",
   "gui.gtceuterminal.schematic_interface.button.load": "§f§l載入",
   "gui.gtceuterminal.schematic_interface.button.delete": "§f§l刪除",
   "gui.gtceuterminal.schematic_interface.button.close": "§7關閉",
-
   "gui.gtceuterminal.schematic_interface.chat.error.no_clipboard": "§c§l錯誤：§c沒有剪貼簿！請先複製一個多方塊。",
   "gui.gtceuterminal.schematic_interface.chat.error.enter_name": "§c§l錯誤：§c請輸入名稱！",
   "gui.gtceuterminal.schematic_interface.chat.error.reserved_name": "§c§l錯誤：§c'Clipboard' 是保留名稱！",
@@ -195,7 +190,6 @@
   "gui.gtceuterminal.schematic_interface.chat.error.no_schematic_selected": "§c§l錯誤：§c未選擇結構！",
   "gui.gtceuterminal.schematic_interface.chat.success.loaded_to_clipboard": "§a§l✓ §a已載入到剪貼簿：§f%s",
   "gui.gtceuterminal.schematic_interface.chat.success.deleted": "§c§l✗ §c已刪除：§f%s",
-
   "gui.gtceuterminal.schematic_interface.fallback.multiblock_structure": "多方塊結構",
 
   "gui.gtceuterminal.multiblock_manager.nearby_title": "附近的多方塊（%s）",
@@ -231,44 +225,36 @@
   "gui.gtceuterminal.energy_analyzer.out_line": "輸出：%s/t（%s/s）",
   "gui.gtceuterminal.energy_analyzer.net_line": "淨增：%s/s",
   "gui.gtceuterminal.energy_analyzer.voltage_line": "電壓：%s（%sV）  %sA 最大",
-
   "gui.gtceuterminal.energy_analyzer.recipe_button": "§6配方：§7[日誌 ▶]",
   "gui.gtceuterminal.energy_analyzer.recipe_time_left": "%s 後完成",
   "gui.gtceuterminal.energy_analyzer.recipe_finishing": "即將完成...",
-
   "gui.gtceuterminal.energy_analyzer.hatches_label": "倉：",
   "gui.gtceuterminal.energy_analyzer.hatch_in": "輸入",
   "gui.gtceuterminal.energy_analyzer.hatch_out": "輸出",
   "gui.gtceuterminal.energy_analyzer.hatch_line": "  %s  %s  %dV%s",
   "gui.gtceuterminal.energy_analyzer.hatch_amp_suffix": " %dA",
   "gui.gtceuterminal.energy_analyzer.more_hatches": "  §8+ %s 個更多...",
-
   "gui.gtceuterminal.energy_analyzer.graph_header": "歷史記錄（EU/s）：",
   "gui.gtceuterminal.energy_analyzer.legend_in": "— 輸入",
   "gui.gtceuterminal.energy_analyzer.legend_out": "— 輸出",
-
   "gui.gtceuterminal.energy_analyzer.machine_options.title": "§6機器選項",
   "gui.gtceuterminal.energy_analyzer.machine_options.rename": "§e✎  重新命名",
   "gui.gtceuterminal.energy_analyzer.machine_options.unlink_machine": "§c✖  解除連線機器",
   "gui.gtceuterminal.energy_analyzer.machine_options.cancel": "§7取消",
-
   "gui.gtceuterminal.energy_analyzer.rename_dialog.title": "§6重新命名機器",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.confirm": "§a確認",
   "gui.gtceuterminal.energy_analyzer.rename_dialog.cancel": "§7取消",
-
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.title": "§c解除連線機器",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.remove_prompt": "§7移除 §f%s§7？",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.unlink": "§c解除連線",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.cancel": "§7取消",
   "gui.gtceuterminal.energy_analyzer.unlink_dialog.hint_click_outside_cancel": "§8點選空白處取消",
-
   "gui.gtceuterminal.energy_analyzer.recipe_log.title": "§6配方日誌  §7— %s",
   "gui.gtceuterminal.energy_analyzer.recipe_log.output": "§7輸出",
   "gui.gtceuterminal.energy_analyzer.recipe_log.time": "§7時間",
   "gui.gtceuterminal.energy_analyzer.recipe_log.when": "§7時間點",
   "gui.gtceuterminal.energy_analyzer.recipe_log.no_recipes": "§7尚無記錄的配方。",
   "gui.gtceuterminal.energy_analyzer.recipe_log.hint_click_outside_close": "§8點選空白處關閉",
-
   "gui.gtceuterminal.energy_analyzer.mode.not_formed": "[未成型]",
   "gui.gtceuterminal.energy_analyzer.mode.consumer": "[消費者]",
   "gui.gtceuterminal.energy_analyzer.mode.generator": "[發電機]",
@@ -276,59 +262,46 @@
   "gui.gtceuterminal.energy_analyzer.mode.unknown": "[未知]",
 
   "gui.gtceuterminal.manager_settings.title": "§l管理設定",
-
   "gui.gtceuterminal.manager_settings.common.yes": "§a是",
   "gui.gtceuterminal.manager_settings.common.no": "§c否",
-
   "gui.gtceuterminal.manager_settings.hatch_mode.label": "§7無倉模式",
   "gui.gtceuterminal.manager_settings.hatch_mode.tooltip": "§7在不使用能源倉/動力倉的情況下建造",
   "gui.gtceuterminal.manager_settings.hatch_mode.hint_toggle": "§8← 點選切換",
-
   "gui.gtceuterminal.manager_settings.tier_mode.label": "§7等級模式",
   "gui.gtceuterminal.manager_settings.tier_mode.tooltip": "§7元件等級（1=LV，2=MV，...）",
   "gui.gtceuterminal.manager_settings.tier_mode.hint_scroll_type": "§8↑↓ 滾動或輸入",
-
   "gui.gtceuterminal.manager_settings.repeat_count.label": "§7重複次數",
   "gui.gtceuterminal.manager_settings.repeat_count.tooltip": "§7結構重複的次數",
   "gui.gtceuterminal.manager_settings.repeat_count.hint_layers": "§8可重複層數（0-99）",
-
   "gui.gtceuterminal.manager_settings.use_ae2.label": "§7使用 AE2",
   "gui.gtceuterminal.manager_settings.use_ae2.tooltip": "§7需要無線終端",
   "gui.gtceuterminal.manager_settings.use_ae2.hint_use_materials": "§8← 使用 AE2 作為材料",
 
   "gui.gtceuterminal.component_detail.header.title_compact": "§l§f%s",
   "gui.gtceuterminal.component_detail.header.title_full": "§l§f%s - 元件",
-
   "gui.gtceuterminal.component_detail.info.multiblock": "§7多方塊：§f%s",
   "gui.gtceuterminal.component_detail.info.tier": "§7等級：§f%s",
   "gui.gtceuterminal.component_detail.info.distance": "§7距離：§f%s",
   "gui.gtceuterminal.component_detail.info.components": "§7元件：§f%s §7(§f%s §7組)",
-
   "gui.gtceuterminal.component_detail.list.header": "§l§7元件組：",
-
   "gui.gtceuterminal.component_detail.entry.count": "§7數量：§f%s",
   "gui.gtceuterminal.component_detail.entry.tier": "§7等級：§f%s",
   "gui.gtceuterminal.component_detail.entry.upgrade": "§a升級",
   "gui.gtceuterminal.component_detail.entry.max": "§7最大",
-
   "gui.gtceuterminal.component_detail.actions.bulk_upgrade": "§a批次升級",
   "gui.gtceuterminal.component_detail.actions.scan": "§7掃描",
   "gui.gtceuterminal.component_detail.actions.back": "§7← 返回",
-
   "gui.gtceuterminal.component_detail.notifications.bulk_not_implemented": "§7批次升級尚未實現",
   "gui.gtceuterminal.component_detail.notifications.rescanned": "§a已重新掃描元件",
   "gui.gtceuterminal.component_detail.notifications.use_esc_to_close": "§7使用 ESC 關閉",
 
   "gui.gtceuterminal.component_detail_dialog.unknown_multiblock": "未知多方塊",
   "gui.gtceuterminal.component_detail_dialog.header.title": "§l§f%s - 元件",
-
   "gui.gtceuterminal.component_detail_dialog.info.multiblock": "§7多方塊：§f%s",
   "gui.gtceuterminal.component_detail_dialog.info.tier": "§7等級：§f%s",
   "gui.gtceuterminal.component_detail_dialog.info.distance": "§7距離：§f%s",
   "gui.gtceuterminal.component_detail_dialog.info.components": "§7元件：§f%s §7(§f%s §7組)",
-
   "gui.gtceuterminal.component_detail_dialog.list.header": "§l§7元件組：",
-
   "gui.gtceuterminal.component_detail_dialog.entry.count": "§7數量：§f%s",
   "gui.gtceuterminal.component_detail_dialog.entry.tier": "§7等級：§f%s",
 
@@ -345,50 +318,84 @@
 
   "gui.gtceuterminal.component_upgrade_dialog.title": "§l§f升級 %s",
 
+  "component.gtceuterminal.component_type.energy_hatch": "Energy Hatch",
+  "component.gtceuterminal.component_type.dynamo_hatch": "Dynamo Hatch",
+  "component.gtceuterminal.component_type.wireless_energy_input": "Wireless Energy Input Hatch",
+  "component.gtceuterminal.component_type.wireless_energy_output": "Wireless Energy Output Hatch",
+  "component.gtceuterminal.component_type.wireless_laser_input": "Wireless Laser Target Hatch",
+  "component.gtceuterminal.component_type.wireless_laser_output": "Wireless Laser Source Hatch",
+  "component.gtceuterminal.component_type.substation_input_energy": "Substation Input Energy",
+  "component.gtceuterminal.component_type.substation_output_energy": "Substation Output Energy",
+  "component.gtceuterminal.component_type.input_bus": "Input Bus",
+  "component.gtceuterminal.component_type.output_bus": "Output Bus",
+  "component.gtceuterminal.component_type.steam_input_bus": "Steam Input Bus",
+  "component.gtceuterminal.component_type.steam_output_bus": "Steam Output Bus",
+  "component.gtceuterminal.component_type.input_hatch": "Input Hatch",
+  "component.gtceuterminal.component_type.output_hatch": "Output Hatch",
+  "component.gtceuterminal.component_type.input_hatch_1x": "Input Hatch (1x)",
+  "component.gtceuterminal.component_type.output_hatch_1x": "Output Hatch (1x)",
+  "component.gtceuterminal.component_type.quad_input_hatch": "Quad Input Hatch (4x)",
+  "component.gtceuterminal.component_type.quad_output_hatch": "Quad Output Hatch (4x)",
+  "component.gtceuterminal.component_type.nonuple_input_hatch": "Nonuple Input Hatch (9x)",
+  "component.gtceuterminal.component_type.nonuple_output_hatch": "Nonuple Output Hatch (9x)",
+  "component.gtceuterminal.component_type.muffler": "Muffler Hatch",
+  "component.gtceuterminal.component_type.maintenance": "Maintenance Hatch",
+  "component.gtceuterminal.component_type.rotor_holder": "Rotor Holder",
+  "component.gtceuterminal.component_type.pump_fluid_hatch": "Pump Fluid Hatch",
+  "component.gtceuterminal.component_type.steam": "Steam Hatch",
+  "component.gtceuterminal.component_type.tank_valve": "Tank Valve",
+  "component.gtceuterminal.component_type.passthrough_hatch": "Passthrough Hatch",
+  "component.gtceuterminal.component_type.parallel_hatch": "Parallel Hatch",
+  "component.gtceuterminal.component_type.input_laser": "Input Laser Hatch",
+  "component.gtceuterminal.component_type.output_laser": "Output Laser Hatch",
+  "component.gtceuterminal.component_type.computation_data_reception": "Computation Data Reception Hatch",
+  "component.gtceuterminal.component_type.computation_data_transmission": "Computation Data Transmission Hatch",
+  "component.gtceuterminal.component_type.optical_data_reception": "Optical Data Reception Hatch",
+  "component.gtceuterminal.component_type.optical_data_transmission": "Optical Data Transmission Hatch",
+  "component.gtceuterminal.component_type.data_access": "Data Access Hatch",
+  "component.gtceuterminal.component_type.hpca_component": "HPCA Component",
+  "component.gtceuterminal.component_type.object_holder": "Object Holder",
+  "component.gtceuterminal.component_type.coil": "Heating Coil",
+  "component.gtceuterminal.component_type.casing": "Casing",
+  "component.gtceuterminal.component_type.machine_hatch": "Machine Hatch",
+  "component.gtceuterminal.component_type.dual_hatch": "Dual Hatch",
+  "component.gtceuterminal.component_type.filter": "Filter",
+  "component.gtceuterminal.component_type.unknown": "Unknown Component",
+
   "gui.gtceuterminal.component_upgrade_dialog.info.count_components": "§7數量：§f%s 個元件",
   "gui.gtceuterminal.component_upgrade_dialog.info.current_tier": "§7當前等級：§f%s",
-
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_upgrade_option": "§l§7選擇升級選項：",
   "gui.gtceuterminal.component_upgrade_dialog.tier_selection.label_target_tier": "§l§7選擇目標等級：",
-
   "gui.gtceuterminal.component_upgrade_dialog.actions.confirm_change": "§e確認更改",
   "gui.gtceuterminal.component_upgrade_dialog.actions.auto_craft": "§9⚙ 自動加工",
   "gui.gtceuterminal.component_upgrade_dialog.actions.cancel": "§f取消",
-
   "gui.gtceuterminal.component_upgrade_dialog.chat.select_upgrade_option_first": "§e請先選擇升級選項。",
   "gui.gtceuterminal.component_upgrade_dialog.chat.analyzing_me_network": "§7正在分析ME網路...",
   "gui.gtceuterminal.component_upgrade_dialog.chat.changing_components": "§a正在更改%s個元件...",
-
   "gui.gtceuterminal.component_upgrade_dialog.materials.required_label": "§l§7所需材料：",
   "gui.gtceuterminal.component_upgrade_dialog.materials.me_materials_verified": "§e⚠ 將在確認時驗證ME材料",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode": "§a§l創造模式",
   "gui.gtceuterminal.component_upgrade_dialog.materials.select_option_to_see": "§7選擇一個選項以檢視材料",
   "gui.gtceuterminal.component_upgrade_dialog.materials.creative_mode_not_required": "§a[創造模式 - 不需要]",
-
   "gui.gtceuterminal.component_upgrade_dialog.option_all_any": "§f全部\n§7(任意)",
 
   "gui.gtceuterminal.material_list.quantity.me": "§a%s§7/%s §a[ME]",
   "gui.gtceuterminal.material_list.quantity.inv": "§7%s/%s [揹包]",
   "gui.gtceuterminal.material_list.quantity.mix": "§e%s§7/%s §e[混合]",
   "gui.gtceuterminal.material_list.quantity.missing": "§c%s§7/%s §c[-%s]",
-
   "gui.gtceuterminal.material_list.tooltip.required": "§7需求：§f%s",
   "gui.gtceuterminal.material_list.tooltip.available_colored": "§7可用：%s",
   "gui.gtceuterminal.material_list.tooltip.sources_header": "§7§l--- 資源來源 ---",
-
   "gui.gtceuterminal.material_list.tooltip.source.inventory_nonzero": "  §7揹包：§f%s",
   "gui.gtceuterminal.material_list.tooltip.source.inventory_zero": "  §8揹包：0",
   "gui.gtceuterminal.material_list.tooltip.source.chests_nonzero": "  §7箱子：§f%s",
   "gui.gtceuterminal.material_list.tooltip.source.chests_zero": "  §8箱子：0",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_nonzero": "  §e§lME網路：§f%s §8(確認時驗證)",
   "gui.gtceuterminal.material_list.tooltip.source.me_network_zero": "  §8ME網路：0",
-
   "gui.gtceuterminal.material_list.tooltip.status.sufficient": "§a✓ 材料充足",
   "gui.gtceuterminal.material_list.tooltip.status.missing": "§c✗ 缺少 %s 個物品",
-
   "gui.gtceuterminal.material_list.tooltip.primary_source.me_pending": "§7主要來源：%s §8(確認時驗證)",
   "gui.gtceuterminal.material_list.tooltip.primary_source.normal": "§7主要來源：%s",
-
   "gui.gtceuterminal.material_list.source.me_network": "ME網路",
   "gui.gtceuterminal.material_list.source.inventory": "揹包",
   "gui.gtceuterminal.material_list.source.chests": "箱子",
@@ -405,7 +412,6 @@
   "gui.gtceuterminal.theme_editor.style.gtceu_native": "GTCEu 原生",
   "gui.gtceuterminal.theme_editor.style.dark": "深色",
   "gui.gtceuterminal.theme_editor.style_label": "§7風格：§f%s",
-
   "gui.gtceuterminal.theme_editor.wallpaper": "§7桌布",
   "gui.gtceuterminal.theme_editor.none": "§8無",
   "gui.gtceuterminal.theme_editor.preview": "§7預覽",
@@ -413,15 +419,12 @@
   "gui.gtceuterminal.theme_editor.tab.accent": "強調色",
   "gui.gtceuterminal.theme_editor.tab.bg": "背景",
   "gui.gtceuterminal.theme_editor.tab.panel": "面板",
-
   "gui.gtceuterminal.theme_editor.options": "§7選項",
   "gui.gtceuterminal.theme_editor.toggle.compact_mode": "緊湊模式",
   "gui.gtceuterminal.theme_editor.toggle.show_tooltips": "顯示提示",
   "gui.gtceuterminal.theme_editor.toggle.show_borders": "顯示邊框",
-
   "gui.gtceuterminal.theme_editor.button.save": "§a儲存",
   "gui.gtceuterminal.theme_editor.button.reset": "§c重置",
-
   "gui.gtceuterminal.theme_editor.preset.default": "預設",
   "gui.gtceuterminal.theme_editor.preset.gtceu_red": "GTCEu 紅色",
   "gui.gtceuterminal.theme_editor.preset.matrix": "矩陣",


### PR DESCRIPTION
Localize Energy Analyzer multiblock names

Store the linked multiblock controller block translation key and use it to render localized controller names in the Energy Analyzer item tooltip and UI, including hatch/bus/dynamo rows. Update language keys and keep fallback support for older saves.